### PR TITLE
gnome-shell: Fix visual glitches when Arc theme is applied to GDM lock/login screens

### DIFF
--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -859,7 +859,7 @@ StScrollBar {
 .ws-switcher-box {
   height: 96px;
   background-color: transparentize(black, 0.67);
-  border-color: transparentize(black, 0.67);
+  border: 1px solid transparentize(black, 0.67);
   border-radius: 2px;
 }
 

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -1680,7 +1680,10 @@ StScrollBar {
   .overview-icon {
     background-color: transparentize(black, 0.5);
     border-radius: 2px;
-    border: 0px solid;
+    border: 0px;
+    padding: 6px;
+    transition-duration: 0ms;
+    text-align: center;
   }
 
   &:hover .overview-icon {

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -257,7 +257,10 @@ StScrollBar {
     }
   }
 
-  .run-dialog-entry { width: 21em; }
+  .run-dialog-entry {
+    width: 21em;
+    margin-bottom: 6px;
+  }
   .run-dialog-error-box {
     padding-top: 5px;
     spacing: 5px;

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -456,7 +456,7 @@ StScrollBar {
     color: $fg_color;
   }
 
-  &-descritption:rtl {
+  &-description:rtl {
     text-align: right;
   }
 
@@ -920,7 +920,7 @@ StScrollBar {
       -panel-corner-border-color: black;
     }
 
-    &.lock-screen, &.login-screen, &unlock-screen {
+    &.lock-screen, &.login-screen, &.unlock-screen {
       -panel-corner-radius: 0;
       -panel-corner-background-color: transparent;
       -panel-corner-border-color: transparent;

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -1585,11 +1585,16 @@ StScrollBar {
   font-size: 1em;
   color: $osd_fg_color;
   background-color: $dark_sidebar_bg;
-  border-color: rgba(0,0,0,0.4);
+  border: 1px solid rgba(0,0,0,0.4);
+  border-left-width: 0;
   padding: 4px 0;
   border-radius: 0 3px 3px 0;
 
-  &:rtl { border-radius: 3px 0 0 3px; }
+  &:rtl {
+    border-left-width: 1px;
+    border-right-width: 0;
+    border-radius: 3px 0 0 3px;
+  }
 
   .right &,
   &:rtl { padding: 4px 0; }

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -1821,8 +1821,8 @@ StScrollBar {
   -arrow-background-color: darken($dark_sidebar_bg, 8%);
   -arrow-border-color: transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   -arrow-border-width: 1px;
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .app-folder-popup-bin { padding: 5px; }

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -686,8 +686,8 @@ StScrollBar {
   -arrow-background-color: $osd_bg_color;
   -arrow-border-width: 1px;
   -arrow-border-color: transparentize(black, 0.6);
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .popup-separator-menu-item {

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -227,6 +227,7 @@ StScrollBar {
     box-shadow: inset 0 0 black;
     border-top-width: if($variant=='light', 0px, 1px);
     border-bottom-width: 0;
+    border-right-width: 1px;
 
     color: $osd_fg_color;
     background-color: $osd_bg_color;

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -125,7 +125,6 @@ StScrollBar {
   StButton#vhandle, StButton#hhandle {
     border-radius: 4px;
     background-color: mix($fg_color, $bg_color, 40%);
-    border: 0px solid;
     margin: 0px;
 
     &:hover { background-color: mix($fg_color, $bg_color, 30%); }

--- a/common/gnome-shell/3.18/sass/_drawing.scss
+++ b/common/gnome-shell/3.18/sass/_drawing.scss
@@ -33,7 +33,7 @@
   @if $t==insensitive {
     color: $insensitive_fg_color;
     background-color: mix($entry_bg, $bg_color, 55%);
-    border-color: 1px solid mix($entry_border, $bg_color, 55%);
+    border: 1px solid mix($entry_border, $bg_color, 55%);
     box-shadow: inset 0 2px 4px transparentize(mix($entry_bg, $bg_color, 55%), 0.95);
   }
 

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -1729,7 +1729,10 @@ StScrollBar {
   .overview-icon {
     background-color: transparentize(black, 0.5);
     border-radius: 2px;
-    border: 0px solid;
+    border: 0px;
+    padding: 6px;
+    transition-duration: 0ms;
+    text-align: center;
   }
 
   &:hover .overview-icon {

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -1870,8 +1870,8 @@ StScrollBar {
   -arrow-background-color: darken($dark_sidebar_bg, 8%);
   -arrow-border-color: transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   -arrow-border-width: 1px;
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .app-folder-popup-bin { padding: 5px; }

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -257,7 +257,10 @@ StScrollBar {
     }
   }
 
-  .run-dialog-entry { width: 21em; }
+  .run-dialog-entry {
+    width: 21em;
+    margin-bottom: 6px;
+  }
   .run-dialog-error-box {
     padding-top: 5px;
     spacing: 5px;

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -874,7 +874,7 @@ StScrollBar {
 .ws-switcher-box {
   height: 96px;
   background-color: transparentize(black, 0.67);
-  border-color: transparentize(black, 0.67);
+  border: 1px solid transparentize(black, 0.67);
   border-radius: 2px;
 }
 

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -1615,11 +1615,16 @@ StScrollBar {
   font-size: 1em;
   color: $osd_fg_color;
   background-color: $dark_sidebar_bg;
-  border-color: rgba(0,0,0,0.4);
+  border: 1px solid rgba(0,0,0,0.4);
+  border-left-width: 0;
   padding: 4px 0;
   border-radius: 0 3px 3px 0;
 
-  &:rtl { border-radius: 3px 0 0 3px; }
+  &:rtl {
+    border-left-width: 1px;
+    border-right-width: 0;
+    border-radius: 3px 0 0 3px;
+  }
 
   .right &,
   &:rtl { padding: 4px 0; }

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -456,7 +456,7 @@ StScrollBar {
     color: $fg_color;
   }
 
-  &-descritption:rtl {
+  &-description:rtl {
     text-align: right;
   }
 
@@ -935,7 +935,7 @@ StScrollBar {
       -panel-corner-border-color: black;
     }
 
-    &.lock-screen, &.login-screen, &unlock-screen {
+    &.lock-screen, &.login-screen, &.unlock-screen {
       -panel-corner-radius: 0;
       -panel-corner-background-color: transparent;
       -panel-corner-border-color: transparent;

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -686,8 +686,8 @@ StScrollBar {
   -arrow-background-color: $osd_bg_color;
   -arrow-border-width: 1px;
   -arrow-border-color: transparentize(black, 0.6);
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .popup-separator-menu-item {

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -227,6 +227,7 @@ StScrollBar {
     box-shadow: inset 0 0 black;
     border-top-width: if($variant=='light', 0px, 1px);
     border-bottom-width: 0;
+    border-right-width: 1px;
 
     color: $osd_fg_color;
     background-color: $osd_bg_color;

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -125,7 +125,6 @@ StScrollBar {
   StButton#vhandle, StButton#hhandle {
     border-radius: 4px;
     background-color: mix($fg_color, $bg_color, 40%);
-    border: 0px solid;
     margin: 0px;
 
     &:hover { background-color: mix($fg_color, $bg_color, 30%); }

--- a/common/gnome-shell/3.24/sass/_drawing.scss
+++ b/common/gnome-shell/3.24/sass/_drawing.scss
@@ -33,7 +33,7 @@
   @if $t==insensitive {
     color: $insensitive_fg_color;
     background-color: mix($entry_bg, $bg_color, 55%);
-    border-color: 1px solid mix($entry_border, $bg_color, 55%);
+    border: 1px solid mix($entry_border, $bg_color, 55%);
     box-shadow: inset 0 2px 4px transparentize(mix($entry_bg, $bg_color, 55%), 0.95);
   }
 

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -1730,7 +1730,10 @@ StScrollBar {
   .overview-icon {
     background-color: transparentize(black, 0.5);
     border-radius: 2px;
-    border: 0px solid;
+    border: 0px;
+    padding: 6px;
+    transition-duration: 0ms;
+    text-align: center;
   }
 
   &:hover .overview-icon {

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -1616,11 +1616,16 @@ StScrollBar {
   font-size: 1em;
   color: $osd_fg_color;
   background-color: $dark_sidebar_bg;
-  border-color: rgba(0,0,0,0.4);
+  border: 1px solid rgba(0,0,0,0.4);
+  border-left-width: 0;
   padding: 4px 0;
   border-radius: 0 3px 3px 0;
 
-  &:rtl { border-radius: 3px 0 0 3px; }
+  &:rtl {
+    border-left-width: 1px;
+    border-right-width: 0;
+    border-radius: 3px 0 0 3px;
+  }
 
   .right &,
   &:rtl { padding: 4px 0; }

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -875,7 +875,7 @@ StScrollBar {
 .ws-switcher-box {
   height: 96px;
   background-color: transparentize(black, 0.67);
-  border-color: transparentize(black, 0.67);
+  border: 1px solid transparentize(black, 0.67);
   border-radius: 2px;
 }
 

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -476,7 +476,7 @@ StScrollBar {
     color: $fg_color;
   }
 
-  &-descritption:rtl {
+  &-description:rtl {
     text-align: right;
   }
 
@@ -936,7 +936,7 @@ StScrollBar {
       -panel-corner-border-color: black;
     }
 
-    &.lock-screen, &.login-screen, &unlock-screen {
+    &.lock-screen, &.login-screen, &.unlock-screen {
       -panel-corner-radius: 0;
       -panel-corner-background-color: transparent;
       -panel-corner-border-color: transparent;

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -257,7 +257,10 @@ StScrollBar {
     }
   }
 
-  .run-dialog-entry { width: 21em; }
+  .run-dialog-entry {
+    width: 21em;
+    margin-bottom: 6px;
+  }
   .run-dialog-error-box {
     padding-top: 5px;
     spacing: 5px;

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -687,8 +687,8 @@ StScrollBar {
   -arrow-background-color: $osd_bg_color;
   -arrow-border-width: 1px;
   -arrow-border-color: transparentize(black, 0.6);
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .popup-separator-menu-item {

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -227,6 +227,7 @@ StScrollBar {
     box-shadow: inset 0 0 black;
     border-top-width: if($variant=='light', 0px, 1px);
     border-bottom-width: 0;
+    border-right-width: 1px;
 
     color: $osd_fg_color;
     background-color: $osd_bg_color;

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -1878,8 +1878,8 @@ StScrollBar {
   -arrow-background-color: darken($dark_sidebar_bg, 8%);
   -arrow-border-color: transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   -arrow-border-width: 1px;
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .app-folder-popup-bin { padding: 5px; }

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -125,7 +125,6 @@ StScrollBar {
   StButton#vhandle, StButton#hhandle {
     border-radius: 4px;
     background-color: mix($fg_color, $bg_color, 40%);
-    border: 0px solid;
     margin: 0px;
 
     &:hover { background-color: mix($fg_color, $bg_color, 30%); }

--- a/common/gnome-shell/3.26/sass/_drawing.scss
+++ b/common/gnome-shell/3.26/sass/_drawing.scss
@@ -33,7 +33,7 @@
   @if $t==insensitive {
     color: $insensitive_fg_color;
     background-color: mix($entry_bg, $bg_color, 55%);
-    border-color: 1px solid mix($entry_border, $bg_color, 55%);
+    border: 1px solid mix($entry_border, $bg_color, 55%);
     box-shadow: inset 0 2px 4px transparentize(mix($entry_bg, $bg_color, 55%), 0.95);
   }
 

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -1885,8 +1885,8 @@ StScrollBar {
   -arrow-background-color: darken($dark_sidebar_bg, 8%);
   -arrow-border-color: transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   -arrow-border-width: 1px;
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .app-folder-popup-bin { padding: 5px; }

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -875,7 +875,7 @@ StScrollBar {
 .ws-switcher-box {
   height: 96px;
   background-color: transparentize(black, 0.67);
-  border-color: transparentize(black, 0.67);
+  border: 1px solid transparentize(black, 0.67);
   border-radius: 2px;
 }
 

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -476,7 +476,7 @@ StScrollBar {
     color: $fg_color;
   }
 
-  &-descritption:rtl {
+  &-description:rtl {
     text-align: right;
   }
 
@@ -936,7 +936,7 @@ StScrollBar {
       -panel-corner-border-color: black;
     }
 
-    &.lock-screen, &.login-screen, &unlock-screen {
+    &.lock-screen, &.login-screen, &.unlock-screen {
       -panel-corner-radius: 0;
       -panel-corner-background-color: transparent;
       -panel-corner-border-color: transparent;

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -257,7 +257,10 @@ StScrollBar {
     }
   }
 
-  .run-dialog-entry { width: 21em; }
+  .run-dialog-entry {
+    width: 21em;
+    margin-bottom: 6px;
+  }
   .run-dialog-error-box {
     padding-top: 5px;
     spacing: 5px;

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -687,8 +687,8 @@ StScrollBar {
   -arrow-background-color: $osd_bg_color;
   -arrow-border-width: 1px;
   -arrow-border-color: transparentize(black, 0.6);
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .popup-separator-menu-item {

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -1737,7 +1737,10 @@ StScrollBar {
   .overview-icon {
     background-color: transparentize(black, 0.5);
     border-radius: 2px;
-    border: 0px solid;
+    border: 0px;
+    padding: 6px;
+    transition-duration: 0ms;
+    text-align: center;
   }
 
   &:hover .overview-icon {

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -1623,11 +1623,16 @@ StScrollBar {
   font-size: 1em;
   color: $osd_fg_color;
   background-color: $dark_sidebar_bg;
-  border-color: rgba(0,0,0,0.4);
+  border: 1px solid rgba(0,0,0,0.4);
+  border-left-width: 0;
   padding: 4px 0;
   border-radius: 0 3px 3px 0;
 
-  &:rtl { border-radius: 3px 0 0 3px; }
+  &:rtl {
+    border-left-width: 1px;
+    border-right-width: 0;
+    border-radius: 3px 0 0 3px;
+  }
 
   .right &,
   &:rtl { padding: 4px 0; }

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -227,6 +227,7 @@ StScrollBar {
     box-shadow: inset 0 0 black;
     border-top-width: if($variant=='light', 0px, 1px);
     border-bottom-width: 0;
+    border-right-width: 1px;
 
     color: $osd_fg_color;
     background-color: $osd_bg_color;

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -125,7 +125,6 @@ StScrollBar {
   StButton#vhandle, StButton#hhandle {
     border-radius: 4px;
     background-color: mix($fg_color, $bg_color, 40%);
-    border: 0px solid;
     margin: 0px;
 
     &:hover { background-color: mix($fg_color, $bg_color, 30%); }

--- a/common/gnome-shell/3.28/sass/_drawing.scss
+++ b/common/gnome-shell/3.28/sass/_drawing.scss
@@ -33,7 +33,7 @@
   @if $t==insensitive {
     color: $insensitive_fg_color;
     background-color: mix($entry_bg, $bg_color, 55%);
-    border-color: 1px solid mix($entry_border, $bg_color, 55%);
+    border: 1px solid mix($entry_border, $bg_color, 55%);
     box-shadow: inset 0 2px 4px transparentize(mix($entry_bg, $bg_color, 55%), 0.95);
   }
 

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -1903,8 +1903,8 @@ StScrollBar {
   -arrow-background-color: darken($dark_sidebar_bg, 8%);
   -arrow-border-color: transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   -arrow-border-width: 1px;
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .app-folder-popup-bin { padding: 5px; }

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -702,8 +702,8 @@ StScrollBar {
   -arrow-background-color: $osd_bg_color;
   -arrow-border-width: 1px;
   -arrow-border-color: transparentize(black, 0.6);
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .popup-separator-menu-item {

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -1641,11 +1641,16 @@ StScrollBar {
   font-size: 1em;
   color: $osd_fg_color;
   background-color: $dark_sidebar_bg;
-  border-color: rgba(0,0,0,0.4);
+  border: 1px solid rgba(0,0,0,0.4);
+  border-left-width: 0;
   padding: 4px 0;
   border-radius: 0 3px 3px 0;
 
-  &:rtl { border-radius: 3px 0 0 3px; }
+  &:rtl {
+    border-left-width: 1px;
+    border-right-width: 0;
+    border-radius: 3px 0 0 3px;
+  }
 
   .right &,
   &:rtl { padding: 4px 0; }

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -479,7 +479,7 @@ StScrollBar {
     color: $fg_color;
   }
 
-  &-descritption:rtl {
+  &-description:rtl {
     text-align: right;
   }
 
@@ -950,7 +950,7 @@ StScrollBar {
       -panel-corner-border-color: black;
     }
 
-    &.lock-screen, &.login-screen, &unlock-screen {
+    &.lock-screen, &.login-screen, &.unlock-screen {
       -panel-corner-radius: 0;
       -panel-corner-background-color: transparent;
       -panel-corner-border-color: transparent;

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -888,7 +888,7 @@ StScrollBar {
 .ws-switcher-box {
   height: 96px;
   background-color: transparentize(black, 0.67);
-  border-color: transparentize(black, 0.67);
+  border: 1px solid transparentize(black, 0.67);
   border-radius: 2px;
 }
 

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -260,7 +260,10 @@ StScrollBar {
     }
   }
 
-  .run-dialog-entry { width: 21em; }
+  .run-dialog-entry {
+    width: 21em;
+    margin-bottom: 6px;
+  }
   .run-dialog-error-box {
     padding-top: 5px;
     spacing: 5px;

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -1755,7 +1755,10 @@ StScrollBar {
   .overview-icon {
     background-color: transparentize(black, 0.5);
     border-radius: 2px;
-    border: 0px solid;
+    border: 0px;
+    padding: 6px;
+    transition-duration: 0ms;
+    text-align: center;
   }
 
   &:hover .overview-icon {

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -230,6 +230,7 @@ StScrollBar {
     box-shadow: inset 0 0 black;
     border-top-width: if($variant=='light', 0px, 1px);
     border-bottom-width: 0;
+    border-right-width: 1px;
 
     color: $osd_fg_color;
     background-color: $osd_bg_color;

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -125,7 +125,6 @@ StScrollBar {
   StButton#vhandle, StButton#hhandle {
     border-radius: 4px;
     background-color: mix($fg_color, $bg_color, 40%);
-    border: 0px solid;
     margin: 0px;
 
     &:hover { background-color: mix($fg_color, $bg_color, 30%); }

--- a/common/gnome-shell/3.30/sass/_drawing.scss
+++ b/common/gnome-shell/3.30/sass/_drawing.scss
@@ -33,7 +33,7 @@
   @if $t==insensitive {
     color: $insensitive_fg_color;
     background-color: mix($entry_bg, $bg_color, 55%);
-    border-color: 1px solid mix($entry_border, $bg_color, 55%);
+    border: 1px solid mix($entry_border, $bg_color, 55%);
     box-shadow: inset 0 2px 4px transparentize(mix($entry_bg, $bg_color, 55%), 0.95);
   }
 

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -1945,8 +1945,8 @@ StScrollBar {
   -arrow-background-color: darken($dark_sidebar_bg, 8%);
   -arrow-border-color: transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   -arrow-border-width: 1px;
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .app-folder-popup-bin { padding: 5px; }

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -889,7 +889,7 @@ StScrollBar {
 .ws-switcher-box {
   height: 96px;
   background-color: transparentize(black, 0.67);
-  border-color: transparentize(black, 0.67);
+  border: 1px solid transparentize(black, 0.67);
   border-radius: 2px;
 }
 

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -1797,7 +1797,10 @@ StScrollBar {
   .overview-icon {
     background-color: transparentize(black, 0.5);
     border-radius: 2px;
-    border: 0px solid;
+    border: 0px;
+    padding: 6px;
+    transition-duration: 0ms;
+    text-align: center;
   }
 
   &:hover .overview-icon {

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -1683,11 +1683,16 @@ StScrollBar {
   font-size: 1em;
   color: $osd_fg_color;
   background-color: $dark_sidebar_bg;
-  border-color: rgba(0,0,0,0.4);
+  border: 1px solid rgba(0,0,0,0.4);
+  border-left-width: 0;
   padding: 4px 0;
   border-radius: 0 3px 3px 0;
 
-  &:rtl { border-radius: 3px 0 0 3px; }
+  &:rtl {
+    border-left-width: 1px;
+    border-right-width: 0;
+    border-radius: 3px 0 0 3px;
+  }
 
   .right &,
   &:rtl { padding: 4px 0; }

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -703,8 +703,8 @@ StScrollBar {
   -arrow-background-color: $osd_bg_color;
   -arrow-border-width: 1px;
   -arrow-border-color: transparentize(black, 0.6);
-  -arrow-base: 5;
-  -arrow-rise: 5;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
 }
 
 .popup-separator-menu-item {

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -479,7 +479,7 @@ StScrollBar {
     color: $fg_color;
   }
 
-  &-descritption:rtl {
+  &-description:rtl {
     text-align: right;
   }
 
@@ -950,7 +950,7 @@ StScrollBar {
       -panel-corner-border-color: black;
     }
 
-    &.lock-screen, &.login-screen, &unlock-screen {
+    &.lock-screen, &.login-screen, &.unlock-screen {
       -panel-corner-radius: 0;
       -panel-corner-background-color: transparent;
       -panel-corner-border-color: transparent;

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -260,7 +260,10 @@ StScrollBar {
     }
   }
 
-  .run-dialog-entry { width: 21em; }
+  .run-dialog-entry {
+    width: 21em;
+    margin-bottom: 6px;
+  }
   .run-dialog-error-box {
     padding-top: 5px;
     spacing: 5px;

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -230,6 +230,7 @@ StScrollBar {
     box-shadow: inset 0 0 black;
     border-top-width: if($variant=='light', 0px, 1px);
     border-bottom-width: 0;
+    border-right-width: 1px;
 
     color: $osd_fg_color;
     background-color: $osd_bg_color;

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -125,7 +125,6 @@ StScrollBar {
   StButton#vhandle, StButton#hhandle {
     border-radius: 4px;
     background-color: mix($fg_color, $bg_color, 40%);
-    border: 0px solid;
     margin: 0px;
 
     &:hover { background-color: mix($fg_color, $bg_color, 30%); }

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -632,6 +632,7 @@ StScrollBar {
     border-image: url("#{$asset_path}/menu/submenu.svg") 9 9 9 9;
 */
     // workaround glitch when closing the sub-menu by not using svg assets
+    padding-bottom: 1px;
     background: if($variant=='light', rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.15));
     box-shadow: inset 0 -1px if($variant=='light', rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.15));
     margin: 0 4px;

--- a/common/gnome-shell/3.32/sass/_drawing.scss
+++ b/common/gnome-shell/3.32/sass/_drawing.scss
@@ -33,7 +33,7 @@
   @if $t==insensitive {
     color: $insensitive_fg_color;
     background-color: mix($entry_bg, $bg_color, 55%);
-    border-color: 1px solid mix($entry_border, $bg_color, 55%);
+    border: 1px solid mix($entry_border, $bg_color, 55%);
     box-shadow: inset 0 2px 4px transparentize(mix($entry_bg, $bg_color, 55%), 0.95);
   }
 


### PR DESCRIPTION
In addition to fixing some typos in the gnome-shell theme (carry-overs from horst's original theme), this PR fixes a few visual glitches that only appear when applying the Arc gnome-shell theme to the GDM login/lock screens (by replacing the default theme located at `/usr/share/gnome-shell/gnome-shell-theme.gresource`, see https://github.com/NicoHood/arc-theme/issues/98).
Essentially this adds some css properties from the default shell theme, that are normally "pulled in" from the default `.gresource` file; if however the default `.gresource` file is replaced with a custom Arc one, these default properties are lost, so to speak.

**Screenshots of visual glitches when using a custom Arc `.gresource` file to style GDM**:

- Missing right border on modal dialog buttons:

   ![modal-dialog-button](https://user-images.githubusercontent.com/18715287/59754161-dbf3bb80-9285-11e9-8190-e0a6b7537b2e.png)

- Reduced/incorrect margin between run dialog entry and button:

   ![run-dialog-entry](https://user-images.githubusercontent.com/18715287/59754245-02195b80-9286-11e9-9a31-9ec119952d15.png)

- Background of last item in popup menu sub-menu overlapping sub-menu bottom border/box-shadow:

   ![popup-menu-sub-menu](https://user-images.githubusercontent.com/18715287/59754367-3ee55280-9286-11e9-8350-fac95a429b6b.png)

- Missing border for boxes in workspace switcher:

   ![workspace-switcher](https://user-images.githubusercontent.com/18715287/59754411-56bcd680-9286-11e9-94c5-7afb796ccdea.png)

- Missing border around dash (dash-to-dock not affected):

   ![dash-border](https://user-images.githubusercontent.com/18715287/59754450-6a683d00-9286-11e9-9e09-26b67562bd4a.png)

- Mis-aligned show apps button in dash (and dash-to-dock):

   ![dash-show-apps](https://user-images.githubusercontent.com/18715287/59754508-853ab180-9286-11e9-8b83-c29f1ddfbee7.png)

- Missing arrow in ibus candidate popup:

   ![ibus-candidate](https://user-images.githubusercontent.com/18715287/59754600-b1eec900-9286-11e9-98bd-ca298544e018.png)

- Missing arrow in overview collection (app folder) popup:

   ![overview-folder](https://user-images.githubusercontent.com/18715287/59754636-c4690280-9286-11e9-8bf0-bcc3c2f0d105.png)
