### PR TITLE
gnome-shell: Adjust clocks/weather buttons active state text colors

### DIFF
--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -1203,12 +1203,16 @@ StScrollBar {
   color: transparentize($fg_color, 0.2);
   font-feature-settings: "tnum";
   font-size: 1.2em;
+
+  .world-clocks-button:active & { color: transparentize($selected_fg_color, 0.2); }
 }
 
 .world-clocks-timezone {
   color: transparentize($fg_color, 0.4);
   font-feature-settings: "tnum";
   font-size: 0.9em;
+
+  .world-clocks-button:active & { color: transparentize($selected_fg_color, 0.4); }
 }
 
 .weather-forecast-icon {
@@ -1218,6 +1222,8 @@ StScrollBar {
 .weather-forecast-time {
   color: transparentize($fg_color, 0.4);
   font-size: 0.8em;
+
+  .weather-button:active & { color: transparentize($selected_fg_color, 0.4); }
 }
 
 .calendar-month-label {


### PR DESCRIPTION
Adjusts text colors in clocks/weather buttons (calendar popup menu) in active state to use selected foreground color (with constant opacity). This is consistent with active state colors for calendar popup menu messages, e.g. for message times (`.message-secondary-bin > .event-time`).

Screenshots:

| Before | After |
| :--- | :--- |
| ![clocks-before](https://user-images.githubusercontent.com/18715287/60387062-54385900-9a9e-11e9-8234-d58ecce6731d.png) | ![clocks-after](https://user-images.githubusercontent.com/18715287/60387149-6a92e480-9a9f-11e9-9fab-c1f36d7f6bce.png) |
| ![weather-before](https://user-images.githubusercontent.com/18715287/60387075-62867500-9a9e-11e9-98aa-803710407c93.png) | ![weather-after](https://user-images.githubusercontent.com/18715287/60387154-741c4c80-9a9f-11e9-82fe-899ce5138b85.png) |



