### PR TITLE
gnome-shell: Fix app folder focused state in overview

### DIFF
--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -1790,7 +1790,7 @@ StScrollBar {
     border: 1px solid transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   }
 
-  &:hover > .overview-icon {
+  &:hover > .overview-icon, &:focus > .overview-icon {
     background-color: lighten($dark_sidebar_bg, 3%);
   }
 
@@ -1798,10 +1798,6 @@ StScrollBar {
     color: $selected_fg_color;
     background-color: $selected_bg_color;
     box-shadow: none;
-  }
-
-  &:focus > .overview-icon {
-    background-color: $selected_bg_color;
   }
 }
 

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -1839,7 +1839,7 @@ StScrollBar {
     border: 1px solid transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   }
 
-  &:hover > .overview-icon {
+  &:hover > .overview-icon, &:focus > .overview-icon {
     background-color: lighten($dark_sidebar_bg, 3%);
   }
 
@@ -1847,10 +1847,6 @@ StScrollBar {
     color: $selected_fg_color;
     background-color: $selected_bg_color;
     box-shadow: none;
-  }
-
-  &:focus > .overview-icon {
-    background-color: $selected_bg_color;
   }
 }
 

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -1847,7 +1847,7 @@ StScrollBar {
     border: 1px solid transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   }
 
-  &:hover > .overview-icon {
+  &:hover > .overview-icon, &:focus > .overview-icon {
     background-color: lighten($dark_sidebar_bg, 3%);
   }
 
@@ -1855,10 +1855,6 @@ StScrollBar {
     color: $selected_fg_color;
     background-color: $selected_bg_color;
     box-shadow: none;
-  }
-
-  &:focus > .overview-icon {
-    background-color: $selected_bg_color;
   }
 }
 

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -1854,7 +1854,7 @@ StScrollBar {
     border: 1px solid transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   }
 
-  &:hover > .overview-icon {
+  &:hover > .overview-icon, &:focus > .overview-icon {
     background-color: lighten($dark_sidebar_bg, 3%);
   }
 
@@ -1862,10 +1862,6 @@ StScrollBar {
     color: $selected_fg_color;
     background-color: $selected_bg_color;
     box-shadow: none;
-  }
-
-  &:focus > .overview-icon {
-    background-color: $selected_bg_color;
   }
 }
 

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -1872,7 +1872,7 @@ StScrollBar {
     border: 1px solid transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   }
 
-  &:hover > .overview-icon {
+  &:hover > .overview-icon, &:focus > .overview-icon {
     background-color: lighten($dark_sidebar_bg, 3%);
   }
 
@@ -1880,10 +1880,6 @@ StScrollBar {
     color: $selected_fg_color;
     background-color: $selected_bg_color;
     box-shadow: none;
-  }
-
-  &:focus > .overview-icon {
-    background-color: $selected_bg_color;
   }
 }
 

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -1913,7 +1913,7 @@ StScrollBar {
     border: 1px solid transparentize(darken($dark_sidebar_bg, 25%), 0.5);
   }
 
-  &:hover > .overview-icon {
+  &:hover > .overview-icon, &:focus > .overview-icon {
     background-color: lighten($dark_sidebar_bg, 3%);
   }
 
@@ -1921,10 +1921,6 @@ StScrollBar {
     color: $selected_fg_color;
     background-color: $selected_bg_color;
     box-shadow: none;
-  }
-
-  &:focus > .overview-icon {
-    background-color: $selected_bg_color;
   }
 }
 


### PR DESCRIPTION
Changes the `:focus` state background color of app folders in overview to
match the `:hover` state. This is consistent with styling of normal app
icons in overview show apps.