### PR TITLE
gnome-shell: Fix unlock/login/lock screens when Arc shell theme is compiled into a .gresource file

### DIFF
--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -908,7 +908,10 @@ StScrollBar {
     .panel-button {
       color: $fg_color;
       &:hover { color: $fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 
@@ -919,7 +922,10 @@ StScrollBar {
     .panel-button {
       color: $osd_fg_color;
       &:hover { color: $osd_fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -2185,7 +2185,7 @@ $legacy_icon_size: 24px;
 }
 
   .login-dialog-logo-bin { padding: 24px 0px; }
-  .login-dialog-banner { color: darken($osd_fg_color,10%); }
+  .login-dialog-banner { color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%)); }
   .login-dialog-button-box { spacing: 5px; }
   .login-dialog-message-warning { color: $warning_color; }
   .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
@@ -2195,14 +2195,14 @@ $legacy_icon_size: 24px;
       padding-left: 2px;
       .login-dialog-not-listed-button:focus &,
       .login-dialog-not-listed-button:hover & {
-        color: $osd_fg_color;
+        color: $fg_color;
       }
     }
   }
   .login-dialog-not-listed-label {
     font-size: 90%;
     font-weight: bold;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     padding-top: 1em;
   }
 
@@ -2217,21 +2217,21 @@ $legacy_icon_size: 24px;
   .login-dialog-user-list-item {
     border-radius: 5px;
     padding: .2em;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     &:ltr { padding-right: 1em; }
     &:rtl { padding-left: 1em; }
     &:hover { background-color: $selected_bg_color; color: $selected_fg_color; }
     .login-dialog-timed-login-indicator {
       height: 2px;
       margin: 2px 0 0 0;
-      background-color: $osd_fg_color;
+      background-color: $fg_color;
     }
     &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
   }
 
   .login-dialog-username,
   .user-widget-label {
-    color: $osd_fg_color;
+    color: $fg_color;
     font-size: 120%;
     font-weight: bold;
     text-align: left;
@@ -2250,7 +2250,7 @@ $legacy_icon_size: 24px;
   }
 
   .login-dialog-prompt-label {
-    color: darken($osd_fg_color, 20%);
+    color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%));
     font-size: 110%;
     padding-top: 1em;
   }
@@ -2260,9 +2260,9 @@ $legacy_icon_size: 24px;
   }
 
   .login-dialog-session-list-button {
-    color: darken($osd_fg_color,30%);
-    &:hover,&:focus { color: $osd_fg_color; }
-    &:active { color: darken($osd_fg_color, 50%); }
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
+    &:hover,&:focus { color: $fg_color; }
+    &:active { color: if($variant=='light', lighten($fg_color, 40%), darken($fg_color, 50%)); }
   }
 
 //

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -905,6 +905,11 @@ StScrollBar {
   &.lock-screen {
     background-color: transparent;
     border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
   }
 
   &:overview { border-image: url('common-assets/panel/panel-overview.svg') 1 1 1 1; }
@@ -964,12 +969,6 @@ StScrollBar {
     }
 
     .system-status-icon { icon-size: 16px; padding: 0 4px; }
-    .unlock-screen &,
-    .login-screen &,
-    .lock-screen & {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
-    }
   }
 
     #panelActivities.panel-button { -natural-hpadding: 12px; }

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -901,9 +901,18 @@ StScrollBar {
   &.dynamic-top-bar-white-btn { border-image: none; }
 
   &.unlock-screen,
-  &.login-screen,
-  &.lock-screen {
+  &.login-screen {
     background-color: transparent;
+    border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
+  }
+
+  &.lock-screen {
+    background-color: transparentize($_bubble_bg_color, 0.5);
     border-image: none;
 
     .panel-button {
@@ -2306,8 +2315,6 @@ $legacy_icon_size: 24px;
 }
 
 .screen-shield-notification-count-text { padding: 0px 0px 0px 12px; }
-
-#panel.lock-screen { background-color: transparentize($_bubble_bg_color, 0.5); }
 
 .screen-shield-background { //just the shadow, really
   background: black;

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -906,8 +906,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $fg_color;
+      &:hover { color: $fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -917,8 +917,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $osd_fg_color;
+      &:hover { color: $osd_fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -2330,7 +2330,7 @@ $legacy_icon_size: 24px;
 }
 
 #lockDialogGroup {
-  background: #2e3436 url(misc/noise-texture.png);
+  background: if($variant=='light', darken($bg_color, 10%), darken($bg_color, 5%));
   background-repeat: repeat;
 }
 

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -2236,6 +2236,8 @@ $legacy_icon_size: 24px;
     font-weight: bold;
     text-align: left;
     padding-left: 15px;
+
+    .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
   }
     .user-widget-label {
       &:ltr { padding-left: 18px; }

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -2244,7 +2244,7 @@ $legacy_icon_size: 24px;
 }
 
   .login-dialog-logo-bin { padding: 24px 0px; }
-  .login-dialog-banner { color: darken($osd_fg_color,10%); }
+  .login-dialog-banner { color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%)); }
   .login-dialog-button-box { spacing: 5px; }
   .login-dialog-message-warning { color: $warning_color; }
   .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
@@ -2254,14 +2254,14 @@ $legacy_icon_size: 24px;
       padding-left: 2px;
       .login-dialog-not-listed-button:focus &,
       .login-dialog-not-listed-button:hover & {
-        color: $osd_fg_color;
+        color: $fg_color;
       }
     }
   }
   .login-dialog-not-listed-label {
     font-size: 90%;
     font-weight: bold;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     padding-top: 1em;
   }
 
@@ -2276,21 +2276,21 @@ $legacy_icon_size: 24px;
   .login-dialog-user-list-item {
     border-radius: 5px;
     padding: .2em;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     &:ltr { padding-right: 1em; }
     &:rtl { padding-left: 1em; }
     &:hover { background-color: $selected_bg_color; color: $selected_fg_color; }
     .login-dialog-timed-login-indicator {
       height: 2px;
       margin: 2px 0 0 0;
-      background-color: $osd_fg_color;
+      background-color: $fg_color;
     }
     &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
   }
 
   .login-dialog-username,
   .user-widget-label {
-    color: $osd_fg_color;
+    color: $fg_color;
     font-size: 120%;
     font-weight: bold;
     text-align: left;
@@ -2309,7 +2309,7 @@ $legacy_icon_size: 24px;
   }
 
   .login-dialog-prompt-label {
-    color: darken($osd_fg_color, 20%);
+    color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%));
     font-size: 110%;
     padding-top: 1em;
   }
@@ -2319,9 +2319,9 @@ $legacy_icon_size: 24px;
   }
 
   .login-dialog-session-list-button {
-    color: darken($osd_fg_color,30%);
-    &:hover,&:focus { color: $osd_fg_color; }
-    &:active { color: darken($osd_fg_color, 50%); }
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
+    &:hover,&:focus { color: $fg_color; }
+    &:active { color: if($variant=='light', lighten($fg_color, 40%), darken($fg_color, 50%)); }
   }
 
 //

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -920,6 +920,11 @@ StScrollBar {
   &.lock-screen {
     background-color: transparent;
     border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
   }
 
   &:overview { border-image: url('common-assets/panel/panel-overview.svg') 1 1 1 1; }
@@ -979,12 +984,6 @@ StScrollBar {
     }
 
     .system-status-icon { icon-size: 16px; padding: 0 4px; }
-    .unlock-screen &,
-    .login-screen &,
-    .lock-screen & {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
-    }
   }
 
     #panelActivities.panel-button { -natural-hpadding: 12px; }

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -2295,6 +2295,8 @@ $legacy_icon_size: 24px;
     font-weight: bold;
     text-align: left;
     padding-left: 15px;
+
+    .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
   }
     .user-widget-label {
       &:ltr { padding-left: 18px; }

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -916,9 +916,18 @@ StScrollBar {
   &.dynamic-top-bar-white-btn { border-image: none; }
 
   &.unlock-screen,
-  &.login-screen,
-  &.lock-screen {
+  &.login-screen {
     background-color: transparent;
+    border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
+  }
+
+  &.lock-screen {
+    background-color: transparentize($_bubble_bg_color, 0.5);
     border-image: none;
 
     .panel-button {
@@ -2365,8 +2374,6 @@ $legacy_icon_size: 24px;
 }
 
 .screen-shield-notification-count-text { padding: 0px 0px 0px 12px; }
-
-#panel.lock-screen { background-color: transparentize($_bubble_bg_color, 0.5); }
 
 .screen-shield-background { //just the shadow, really
   background: black;

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -2389,7 +2389,7 @@ $legacy_icon_size: 24px;
 }
 
 #lockDialogGroup {
-  background: #2e3436 url(misc/noise-texture.png);
+  background: if($variant=='light', darken($bg_color, 10%), darken($bg_color, 5%));
   background-repeat: repeat;
 }
 

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -923,7 +923,10 @@ StScrollBar {
     .panel-button {
       color: $fg_color;
       &:hover { color: $fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 
@@ -934,7 +937,10 @@ StScrollBar {
     .panel-button {
       color: $osd_fg_color;
       &:hover { color: $osd_fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -921,8 +921,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $fg_color;
+      &:hover { color: $fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.24/sass/_common.scss
+++ b/common/gnome-shell/3.24/sass/_common.scss
@@ -932,8 +932,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $osd_fg_color;
+      &:hover { color: $osd_fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -2372,7 +2372,7 @@ StScrollBar {
 }
 
 #lockDialogGroup {
-  background: #2e3436 url(misc/noise-texture.png);
+  background: if($variant=='light', darken($bg_color, 10%), darken($bg_color, 5%));
   background-repeat: repeat;
 }
 

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -917,9 +917,18 @@ StScrollBar {
   &.dynamic-top-bar-white-btn { border-image: none; }
 
   &.unlock-screen,
-  &.login-screen,
-  &.lock-screen {
+  &.login-screen {
     background-color: transparent;
+    border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
+  }
+
+  &.lock-screen {
+    background-color: transparentize($_bubble_bg_color, 0.5);
     border-image: none;
 
     .panel-button {
@@ -2348,8 +2357,6 @@ StScrollBar {
 }
 
 .screen-shield-notification-count-text { padding: 0px 0px 0px 12px; }
-
-#panel.lock-screen { background-color: transparentize($_bubble_bg_color, 0.5); }
 
 .screen-shield-background { //just the shadow, really
   background: black;

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -924,7 +924,10 @@ StScrollBar {
     .panel-button {
       color: $fg_color;
       &:hover { color: $fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 
@@ -935,7 +938,10 @@ StScrollBar {
     .panel-button {
       color: $osd_fg_color;
       &:hover { color: $osd_fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -922,8 +922,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $fg_color;
+      &:hover { color: $fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -2278,6 +2278,8 @@ StScrollBar {
     font-weight: bold;
     text-align: left;
     padding-left: 15px;
+
+    .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
   }
     .user-widget-label {
       &:ltr { padding-left: 18px; }

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -921,6 +921,11 @@ StScrollBar {
   &.lock-screen {
     background-color: transparent;
     border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
   }
 
   &:overview { border-image: url('common-assets/panel/panel-overview.svg') 1 1 1 1; }
@@ -987,12 +992,6 @@ StScrollBar {
     }
 
     .system-status-icon { icon-size: 16px; padding: 0 4px; }
-    .unlock-screen &,
-    .login-screen &,
-    .lock-screen & {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
-    }
   }
 
     #panelActivities.panel-button { -natural-hpadding: 12px; }

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -933,8 +933,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $osd_fg_color;
+      &:hover { color: $osd_fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.26/sass/_common.scss
+++ b/common/gnome-shell/3.26/sass/_common.scss
@@ -2230,7 +2230,7 @@ StScrollBar {
 }
 
   .login-dialog-logo-bin { padding: 24px 0px; }
-  .login-dialog-banner { color: darken($osd_fg_color,10%); }
+  .login-dialog-banner { color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%)); }
   .login-dialog-button-box { spacing: 5px; }
   .login-dialog-message-warning { color: $warning_color; }
   .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
@@ -2239,13 +2239,13 @@ StScrollBar {
     padding-left: 2px;
     .login-dialog-not-listed-button:focus &,
     .login-dialog-not-listed-button:hover & {
-      color: $osd_fg_color;
+      color: $fg_color;
     }
   }
   .login-dialog-not-listed-label {
     font-size: 90%;
     font-weight: bold;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     padding-top: 1em;
   }
 
@@ -2260,20 +2260,20 @@ StScrollBar {
   .login-dialog-user-list-item {
     border-radius: 5px;
     padding: .2em;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     &:ltr { padding-right: 1em; }
     &:rtl { padding-left: 1em; }
     .login-dialog-timed-login-indicator {
       height: 2px;
       margin: 2px 0 0 0;
-      background-color: $osd_fg_color;
+      background-color: $fg_color;
     }
     &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
   }
 
   .login-dialog-username,
   .user-widget-label {
-    color: $osd_fg_color;
+    color: $fg_color;
     font-size: 120%;
     font-weight: bold;
     text-align: left;
@@ -2292,7 +2292,7 @@ StScrollBar {
   }
 
   .login-dialog-prompt-label {
-    color: darken($osd_fg_color, 20%);
+    color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%));
     font-size: 110%;
     padding-top: 1em;
   }
@@ -2302,9 +2302,9 @@ StScrollBar {
   }
 
   .login-dialog-session-list-button {
-    color: darken($osd_fg_color,30%);
-    &:hover,&:focus { color: $osd_fg_color; }
-    &:active { color: darken($osd_fg_color, 50%); }
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
+    &:hover,&:focus { color: $fg_color; }
+    &:active { color: if($variant=='light', lighten($fg_color, 40%), darken($fg_color, 50%)); }
   }
 
 //

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -2321,6 +2321,8 @@ StScrollBar {
     font-weight: bold;
     text-align: left;
     padding-left: 15px;
+
+    .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
   }
     .user-widget-label {
       &:ltr { padding-left: 18px; }

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -2418,7 +2418,7 @@ StScrollBar {
 }
 
 #lockDialogGroup {
-  background: #2e3436 url(misc/noise-texture.png);
+  background: if($variant=='light', darken($bg_color, 10%), darken($bg_color, 5%));
   background-repeat: repeat;
 }
 

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -924,7 +924,10 @@ StScrollBar {
     .panel-button {
       color: $fg_color;
       &:hover { color: $fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 
@@ -935,7 +938,10 @@ StScrollBar {
     .panel-button {
       color: $osd_fg_color;
       &:hover { color: $osd_fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -922,8 +922,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $fg_color;
+      &:hover { color: $fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -921,6 +921,11 @@ StScrollBar {
   &.lock-screen {
     background-color: transparent;
     border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
   }
 
   &:overview { border-image: url('common-assets/panel/panel-overview.svg') 1 1 1 1; }
@@ -987,12 +992,6 @@ StScrollBar {
     }
 
     .system-status-icon { icon-size: 16px; padding: 0 4px; }
-    .unlock-screen &,
-    .login-screen &,
-    .lock-screen & {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
-    }
   }
 
     #panelActivities.panel-button { -natural-hpadding: 12px; }

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -917,9 +917,18 @@ StScrollBar {
   &.dynamic-top-bar-white-btn { border-image: none; }
 
   &.unlock-screen,
-  &.login-screen,
-  &.lock-screen {
+  &.login-screen {
     background-color: transparent;
+    border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
+  }
+
+  &.lock-screen {
+    background-color: transparentize($_bubble_bg_color, 0.5);
     border-image: none;
 
     .panel-button {
@@ -2394,8 +2403,6 @@ StScrollBar {
 }
 
 .screen-shield-notification-count-text { padding: 0px 0px 0px 12px; }
-
-#panel.lock-screen { background-color: transparentize($_bubble_bg_color, 0.5); }
 
 .screen-shield-background { //just the shadow, really
   background: black;

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -933,8 +933,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $osd_fg_color;
+      &:hover { color: $osd_fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -2273,7 +2273,7 @@ StScrollBar {
 }
 
   .login-dialog-logo-bin { padding: 24px 0px; }
-  .login-dialog-banner { color: darken($osd_fg_color,10%); }
+  .login-dialog-banner { color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%)); }
   .login-dialog-button-box { spacing: 5px; }
   .login-dialog-message-warning { color: $warning_color; }
   .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
@@ -2282,13 +2282,13 @@ StScrollBar {
     padding-left: 2px;
     .login-dialog-not-listed-button:focus &,
     .login-dialog-not-listed-button:hover & {
-      color: $osd_fg_color;
+      color: $fg_color;
     }
   }
   .login-dialog-not-listed-label {
     font-size: 90%;
     font-weight: bold;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     padding-top: 1em;
   }
 
@@ -2303,20 +2303,20 @@ StScrollBar {
   .login-dialog-user-list-item {
     border-radius: 5px;
     padding: .2em;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     &:ltr { padding-right: 1em; }
     &:rtl { padding-left: 1em; }
     .login-dialog-timed-login-indicator {
       height: 2px;
       margin: 2px 0 0 0;
-      background-color: $osd_fg_color;
+      background-color: $fg_color;
     }
     &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
   }
 
   .login-dialog-username,
   .user-widget-label {
-    color: $osd_fg_color;
+    color: $fg_color;
     font-size: 120%;
     font-weight: bold;
     text-align: left;
@@ -2335,7 +2335,7 @@ StScrollBar {
   }
 
   .login-dialog-prompt-label {
-    color: darken($osd_fg_color, 20%);
+    color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%));
     font-size: 110%;
     padding-top: 1em;
   }
@@ -2345,9 +2345,9 @@ StScrollBar {
   }
 
   .login-dialog-session-list-button {
-    color: darken($osd_fg_color,30%);
-    &:hover,&:focus { color: $osd_fg_color; }
-    &:active { color: darken($osd_fg_color, 50%); }
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
+    &:hover,&:focus { color: $fg_color; }
+    &:active { color: if($variant=='light', lighten($fg_color, 40%), darken($fg_color, 50%)); }
   }
 
 //

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -938,7 +938,10 @@ StScrollBar {
     .panel-button {
       color: $fg_color;
       &:hover { color: $fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 
@@ -949,7 +952,10 @@ StScrollBar {
     .panel-button {
       color: $osd_fg_color;
       &:hover { color: $osd_fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -931,9 +931,18 @@ StScrollBar {
   &.dynamic-top-bar-white-btn { border-image: none; }
 
   &.unlock-screen,
-  &.login-screen,
-  &.lock-screen {
+  &.login-screen {
     background-color: transparent;
+    border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
+  }
+
+  &.lock-screen {
+    background-color: transparentize($_bubble_bg_color, 0.5);
     border-image: none;
 
     .panel-button {
@@ -2412,8 +2421,6 @@ StScrollBar {
 }
 
 .screen-shield-notification-count-text { padding: 0px 0px 0px 12px; }
-
-#panel.lock-screen { background-color: transparentize($_bubble_bg_color, 0.5); }
 
 .screen-shield-background { //just the shadow, really
   background: black;

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -2291,7 +2291,7 @@ StScrollBar {
 }
 
   .login-dialog-logo-bin { padding: 24px 0px; }
-  .login-dialog-banner { color: darken($osd_fg_color,10%); }
+  .login-dialog-banner { color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%)); }
   .login-dialog-button-box { spacing: 5px; }
   .login-dialog-message-warning { color: $warning_color; }
   .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
@@ -2300,13 +2300,13 @@ StScrollBar {
     padding-left: 2px;
     .login-dialog-not-listed-button:focus &,
     .login-dialog-not-listed-button:hover & {
-      color: $osd_fg_color;
+      color: $fg_color;
     }
   }
   .login-dialog-not-listed-label {
     font-size: 90%;
     font-weight: bold;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     padding-top: 1em;
   }
 
@@ -2320,20 +2320,20 @@ StScrollBar {
   .login-dialog-user-list-item {
     border-radius: 5px;
     padding: 6px;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     &:ltr .user-widget { padding-right: 1em; }
     &:rtl .user-widget { padding-left: 1em; }
     .login-dialog-timed-login-indicator {
       height: 2px;
       margin-top: 6px;
-      background-color: $osd_fg_color;
+      background-color: $fg_color;
     }
     &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
   }
 
   .login-dialog-username,
   .user-widget-label {
-    color: $osd_fg_color;
+    color: $fg_color;
     font-size: 120%;
     font-weight: bold;
     text-align: left;
@@ -2352,7 +2352,7 @@ StScrollBar {
   }
 
   .login-dialog-prompt-label {
-    color: darken($osd_fg_color, 20%);
+    color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%));
     font-size: 110%;
     padding-top: 1em;
   }
@@ -2362,9 +2362,9 @@ StScrollBar {
   }
 
   .login-dialog-session-list-button {
-    color: darken($osd_fg_color,30%);
-    &:hover,&:focus { color: $osd_fg_color; }
-    &:active { color: darken($osd_fg_color, 50%); }
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
+    &:hover,&:focus { color: $fg_color; }
+    &:active { color: if($variant=='light', lighten($fg_color, 40%), darken($fg_color, 50%)); }
   }
 
 //

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -2338,6 +2338,8 @@ StScrollBar {
     font-weight: bold;
     text-align: left;
     padding-left: 15px;
+
+    .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
   }
     .user-widget-label {
       &:ltr { padding-left: 14px; }

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -2436,7 +2436,7 @@ StScrollBar {
 }
 
 #lockDialogGroup {
-  background: #2e3436 url(misc/noise-texture.png);
+  background: if($variant=='light', darken($bg_color, 10%), darken($bg_color, 5%));
   background-repeat: repeat;
 }
 

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -947,8 +947,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $osd_fg_color;
+      &:hover { color: $osd_fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -935,6 +935,11 @@ StScrollBar {
   &.lock-screen {
     background-color: transparent;
     border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
   }
 
   &:overview { border-image: url('common-assets/panel/panel-overview.svg') 1 1 1 1; }
@@ -1001,12 +1006,6 @@ StScrollBar {
     }
 
     .system-status-icon { icon-size: 16px; padding: 0 4px; }
-    .unlock-screen &,
-    .login-screen &,
-    .lock-screen & {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
-    }
   }
 
     #panelActivities.panel-button { -natural-hpadding: 12px; }

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -936,8 +936,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $fg_color;
+      &:hover { color: $fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -932,9 +932,18 @@ StScrollBar {
   &.dynamic-top-bar-white-btn { border-image: none; }
 
   &.unlock-screen,
-  &.login-screen,
-  &.lock-screen {
+  &.login-screen {
     background-color: transparent;
+    border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
+  }
+
+  &.lock-screen {
+    background-color: transparentize($_bubble_bg_color, 0.5);
     border-image: none;
 
     .panel-button {
@@ -2480,8 +2489,6 @@ StScrollBar {
 }
 
 .screen-shield-notification-count-text { padding: 0px 0px 0px 12px; }
-
-#panel.lock-screen { background-color: transparentize($_bubble_bg_color, 0.5); }
 
 .screen-shield-background { //just the shadow, really
   background: black;

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -2504,7 +2504,7 @@ StScrollBar {
 }
 
 #lockDialogGroup {
-  background: #2e3436 url(misc/noise-texture.png);
+  background: if($variant=='light', darken($bg_color, 10%), darken($bg_color, 5%));
   background-repeat: repeat;
 }
 

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -936,6 +936,11 @@ StScrollBar {
   &.lock-screen {
     background-color: transparent;
     border-image: none;
+
+    .panel-button {
+      color: lighten($fg_color, 10%);
+      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+    }
   }
 
   &:overview { border-image: url('common-assets/panel/panel-overview.svg') 1 1 1 1; }
@@ -1002,12 +1007,6 @@ StScrollBar {
     }
 
     .system-status-icon { icon-size: 16px; padding: 0 4px; }
-    .unlock-screen &,
-    .login-screen &,
-    .lock-screen & {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
-    }
   }
 
     #panelActivities.panel-button { -natural-hpadding: 12px; }

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -2406,6 +2406,8 @@ StScrollBar {
     font-weight: bold;
     text-align: left;
     padding-left: 15px;
+
+    .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
   }
     .user-widget-label {
       &:ltr { padding-left: 14px; }

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -937,8 +937,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $fg_color;
+      &:hover { color: $fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -948,8 +948,9 @@ StScrollBar {
     border-image: none;
 
     .panel-button {
-      color: lighten($fg_color, 10%);
-      &:focus, &:hover, &:active { color: lighten($fg_color, 10%); }
+      color: $osd_fg_color;
+      &:hover { color: $osd_fg_color; }
+      &:focus, &:active, &:checked { color: $selected_fg_color; }
     }
   }
 

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -2359,7 +2359,7 @@ StScrollBar {
 }
 
   .login-dialog-logo-bin { padding: 24px 0px; }
-  .login-dialog-banner { color: darken($osd_fg_color,10%); }
+  .login-dialog-banner { color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%)); }
   .login-dialog-button-box { spacing: 5px; }
   .login-dialog-message-warning { color: $warning_color; }
   .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
@@ -2368,13 +2368,13 @@ StScrollBar {
     padding-left: 2px;
     .login-dialog-not-listed-button:focus &,
     .login-dialog-not-listed-button:hover & {
-      color: $osd_fg_color;
+      color: $fg_color;
     }
   }
   .login-dialog-not-listed-label {
     font-size: 90%;
     font-weight: bold;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     padding-top: 1em;
   }
 
@@ -2388,20 +2388,20 @@ StScrollBar {
   .login-dialog-user-list-item {
     border-radius: 5px;
     padding: 6px;
-    color: darken($osd_fg_color,30%);
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
     &:ltr .user-widget { padding-right: 1em; }
     &:rtl .user-widget { padding-left: 1em; }
     .login-dialog-timed-login-indicator {
       height: 2px;
       margin-top: 6px;
-      background-color: $osd_fg_color;
+      background-color: $fg_color;
     }
     &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
   }
 
   .login-dialog-username,
   .user-widget-label {
-    color: $osd_fg_color;
+    color: $fg_color;
     font-size: 120%;
     font-weight: bold;
     text-align: left;
@@ -2420,7 +2420,7 @@ StScrollBar {
   }
 
   .login-dialog-prompt-label {
-    color: darken($osd_fg_color, 20%);
+    color: if($variant=='light', lighten($fg_color, 10%), darken($fg_color, 20%));
     font-size: 110%;
     padding-top: 1em;
   }
@@ -2430,9 +2430,9 @@ StScrollBar {
   }
 
   .login-dialog-session-list-button {
-    color: darken($osd_fg_color,30%);
-    &:hover,&:focus { color: $osd_fg_color; }
-    &:active { color: darken($osd_fg_color, 50%); }
+    color: if($variant=='light', lighten($fg_color, 20%), darken($fg_color, 30%));
+    &:hover,&:focus { color: $fg_color; }
+    &:active { color: if($variant=='light', lighten($fg_color, 40%), darken($fg_color, 50%)); }
   }
 
 //

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -939,7 +939,10 @@ StScrollBar {
     .panel-button {
       color: $fg_color;
       &:hover { color: $fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 
@@ -950,7 +953,10 @@ StScrollBar {
     .panel-button {
       color: $osd_fg_color;
       &:hover { color: $osd_fg_color; }
-      &:focus, &:active, &:checked { color: $selected_fg_color; }
+      &:focus, &:active, &:checked {
+        color: $selected_fg_color;
+        border-color: transparent;
+      }
     }
   }
 


### PR DESCRIPTION
When the Arc theme is compiled into a `.gresource` file, the `.panel-button` in login/lock screens has an unnecessary/incongruous black bottom border (in `:active`/`:checked` states):

![gdm-panel-button](https://user-images.githubusercontent.com/18715287/61591387-b3354d80-abc6-11e9-8591-f2baaf08b24a.png)

This PR replaces the black border with a transparent one. It also fixes the SCSS selectors for the `.panel-button` in login/lock screens, which are incorrect (this appears to be an upstream bug). Finally, it adds a SCSS selector for the `.panel-button:checked` state in login/lock screens.