### PR TITLE
gnome-shell: Add styling for OSK word suggestions

### DIFF
--- a/common/gnome-shell/3.28/sass/_common.scss
+++ b/common/gnome-shell/3.28/sass/_common.scss
@@ -2105,6 +2105,14 @@ StScrollBar {
   font-size: 14pt;
   spacing: 12px;
   min-height: 20pt;
+
+  StButton {
+    padding: 0 0.5em;
+    border-radius: 2px;
+    color: $osd_fg_color;
+
+    &:hover, &:focus, &:active { background-color: $selected_bg_color; color: $selected_fg_color; }
+  }
 }
 
 #keyboard {

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -2123,6 +2123,14 @@ StScrollBar {
   font-size: 14pt;
   spacing: 12px;
   min-height: 20pt;
+
+  StButton {
+    padding: 0 0.5em;
+    border-radius: 2px;
+    color: $osd_fg_color;
+
+    &:hover, &:focus, &:active { background-color: $selected_bg_color; color: $selected_fg_color; }
+  }
 }
 
 #keyboard {

--- a/common/gnome-shell/3.32/sass/_common.scss
+++ b/common/gnome-shell/3.32/sass/_common.scss
@@ -2168,6 +2168,14 @@ StScrollBar {
   font-size: 14pt;
   spacing: 12px;
   min-height: 20pt;
+
+  StButton {
+    padding: 0 0.5em;
+    border-radius: 2px;
+    color: $osd_fg_color;
+
+    &:hover, &:focus, &:active { background-color: $selected_bg_color; color: $selected_fg_color; }
+  }
 }
 
 #keyboard {


### PR DESCRIPTION
Adds styling for word suggestions in OSK, when using non-Latin
languages; styling mimics `.candidate-box` styling in IBUS candidate
popup.

![osk-word-suggestions](https://user-images.githubusercontent.com/18715287/61996870-dade5700-b099-11e9-9542-492b5003ab49.png)

Screenshot of IBUS candidate popup for comparison:

![ibus-popup](https://user-images.githubusercontent.com/18715287/61996898-2abd1e00-b09a-11e9-814d-985da7b32ffb.png)
