### PR TITLE
Fix non-flat panel buttons on xfce4-panel 4.14

### DIFF
--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -763,7 +763,7 @@ panel-toplevel.background {
   text-shadow: none;
   -gtk-icon-shadow: none;
 
-  button.flat { @extend %panelbutton; }
+  button { @extend %panelbutton; }
 }
 
 #tasklist-button {


### PR DESCRIPTION
_Moved PR from NicoHood/arc-theme to here._
Since xfce 4.14 the 'Window Buttons' panel visuals are 'broken' if the 'show flat buttons' option is not enabled.
![flat](https://user-images.githubusercontent.com/5833571/62892733-49cdd800-bd49-11e9-9772-3afff7bf8698.png)

This setting used to have no effect on the visuals on 4.12.

Old situation (xfce4-panel 4.12 - flat enabled):
![old-flat](https://user-images.githubusercontent.com/5833571/62893123-150e5080-bd4a-11e9-89a9-d9a533bab628.png)
Old situation (xfce4-panel 4.12 - flat disabled):
![old-non-flat](https://user-images.githubusercontent.com/5833571/62893149-20617c00-bd4a-11e9-813a-dabb6eacc254.jpg)

Broken (xfce4-panel 4.14 - flat disabled):
![broken](https://user-images.githubusercontent.com/5833571/62892672-2571fb80-bd49-11e9-93b8-faf2b489c4c1.jpg)

New (xfce4-panel 4.14 with this PR - flat enabled):
![new-flat](https://user-images.githubusercontent.com/5833571/62893240-60c0fa00-bd4a-11e9-873e-7d7a51141441.png)
New (xfce4-panel 4.14 with this PR - flat disabled):
![new-non-flat](https://user-images.githubusercontent.com/5833571/62893245-63235400-bd4a-11e9-93fe-e268ba4447a6.png)