### PR TITLE
Xfce4-panel 4.14 fixes

### DIFF
--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -763,6 +763,7 @@ panel-toplevel.background {
   text-shadow: none;
   -gtk-icon-shadow: none;
 
+  label { font-weight: normal; }
   button { @extend %panelbutton; }
 }
 

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -763,6 +763,7 @@ panel-toplevel.background {
   text-shadow: none;
   -gtk-icon-shadow: none;
 
+  frame > border { border: 0; }
   label { font-weight: normal; }
   button { @extend %panelbutton; }
 }


### PR DESCRIPTION
Two fixups for xfce 4.14:

- The font-weight of the taskbar changed:
**Old (xfce4.12)**
![Screenshot_2019-08-25_14-21-57](https://user-images.githubusercontent.com/5833571/63650115-60abfb80-c747-11e9-96fa-63b0913cf1f9.png)
**New (xfce4.14)**
![Screenshot_2019-08-25_14-23-20](https://user-images.githubusercontent.com/5833571/63650119-6e618100-c747-11e9-9aa6-916c4a202b57.png)
**New (xfce4.14) with PR**
![Screenshot_2019-08-25_14-27-40](https://user-images.githubusercontent.com/5833571/63650129-90f39a00-c747-11e9-8b40-e00d121f67f9.png)

- Ugly border around the systray with 'show frame' enabled:
![Screenshot_2019-08-25_14-51-18](https://user-images.githubusercontent.com/5833571/63650152-d87a2600-c747-11e9-9ec8-789677e34be9.png)
**Old (xfce4.12)**
![Screenshot_2019-08-25_13-28-18](https://user-images.githubusercontent.com/5833571/63650163-f0ea4080-c747-11e9-8169-7a4003db9b90.png)
**New (xfce4.14)**
![Screenshot_2019-08-25_14-30-03](https://user-images.githubusercontent.com/5833571/63650170-fc3d6c00-c747-11e9-80af-eeb11b2141f8.png)
**New (xfce4.14) with PR**
![Screenshot_2019-08-25_14-36-39](https://user-images.githubusercontent.com/5833571/63650173-ffd0f300-c747-11e9-850d-c5c3b3c80382.png)
