### PR TITLE
build: Output GTK3 CSS relative to work dir

### DIFF
--- a/common/gtk-3.0/common.am
+++ b/common/gtk-3.0/common.am
@@ -33,12 +33,12 @@ endif
 
 if ENABLE_TRANSPARENCY
 %.css: FORCE
-	$(SASSC) "$(srcdir)/sass/$*.scss" "$(srcdir)/$@"
+	$(SASSC) "$(srcdir)/sass/$*.scss" "$@"
 else
 gtk.css: FORCE
-	$(SASSC) "$(srcdir)/sass/gtk-solid.scss" "$(srcdir)/$@"
+	$(SASSC) "$(srcdir)/sass/gtk-solid.scss" "$@"
 gtk-%.css: FORCE
-	$(SASSC) "$(srcdir)/sass/gtk-solid-$*.scss" "$(srcdir)/$@"
+	$(SASSC) "$(srcdir)/sass/gtk-solid-$*.scss" "$@"
 endif
 
 FORCE:


### PR DESCRIPTION
Fixes #29.

Did some digging and yes it's not too uncommon to build projects that use autoconf/automake in a different directory (by e.g. just calling configure from inside where you want to build it, which is the same as specifying the srcdir flag). Furthermore, I looked at the history of the gtk-3.0 files (since this used to work) and concluded that what had changed was the common.am file. I'm guessing the change of the sass output directory was not directly intentional since it doesn't solve any other problems afaik. Now the sass files get built and outputted in the expected location, just like how it was originally.

You're welcome to do what you want with this PR, but I, of course, hope that you'll consider merging it. The build still works fine the normal way (according to INSTALL.md) after this change is applied.