### PR TITLE
Gtk3: Fix levelbar min-width and min-height

### DIFF
--- a/common/gtk-3.0/3.22/sass/_common.scss
+++ b/common/gtk-3.0/3.22/sass/_common.scss
@@ -2426,13 +2426,26 @@ progressbar {
 // Level Bar
 //
 levelbar {
-  block {
-    min-width: 32px;
-    min-height: 1px;
+  &.horizontal {
+    block {
+      min-height: 1px;
+    }
+
+    &.discrete block {
+      margin: 0 1px;
+      min-width: 32px;
+    }
   }
-  &.vertical block {
-    min-width: 1px;
-    min-height: 32px;
+
+  &.vertical {
+    block {
+      min-width: 1px;
+    }
+
+    &.discrete block {
+      margin: 1px 0;
+      min-height: 32px;
+    }
   }
 
   trough {
@@ -2441,9 +2454,6 @@ levelbar {
     border-radius: 3px;
     background-color: if($variant != 'dark', $button_border, darken($bg_color, 5%));
   }
-
-  &.horizontal.discrete block { margin: 0 1px; }
-  &.vertical.discrete block { margin: 1px 0; }
 
   block:not(.empty) {
     border: 1px solid $selected_bg_color;

--- a/common/gtk-3.0/3.24/sass/_common.scss
+++ b/common/gtk-3.0/3.24/sass/_common.scss
@@ -2428,13 +2428,26 @@ progressbar {
 // Level Bar
 //
 levelbar {
-  block {
-    min-width: 32px;
-    min-height: 1px;
+  &.horizontal {
+    block {
+      min-height: 1px;
+    }
+
+    &.discrete block {
+      margin: 0 1px;
+      min-width: 32px;
+    }
   }
-  &.vertical block {
-    min-width: 1px;
-    min-height: 32px;
+
+  &.vertical {
+    block {
+      min-width: 1px;
+    }
+
+    &.discrete block {
+      margin: 1px 0;
+      min-height: 32px;
+    }
   }
 
   trough {
@@ -2443,9 +2456,6 @@ levelbar {
     border-radius: 3px;
     background-color: if($variant != 'dark', $button_border, darken($bg_color, 5%));
   }
-
-  &.horizontal.discrete block { margin: 0 1px; }
-  &.vertical.discrete block { margin: 1px 0; }
 
   block:not(.empty) {
     border: 1px solid $selected_bg_color;


### PR DESCRIPTION
The min-width of the horizontal and the min-height of the vertical levelbar are hardcoded to 32px. Because of that, the levelbars always show 32px wide/high load. Here are two screenshots demonstrating the issue:

Screenshot of [GtkStressTesting](https://gitlab.com/leinardi/gst):
![Screenshot_2020-05-13_03-27-37](https://user-images.githubusercontent.com/7719590/81761360-0c5dcd00-94ca-11ea-9c1f-439e768fcf88.png)

Screenshot of [GreenWithEnvy](https://gitlab.com/leinardi/gwe/):
![Screenshot_2020-05-13_03-28-11](https://user-images.githubusercontent.com/7719590/81761401-21d2f700-94ca-11ea-8958-493db0bd165a.png)


This pull request changes the min-width/min-height from 32px to 1px.