### PR TITLE
Replace Inkscape dependency with rsvg-convert

### DIFF
--- a/common/gtk-2.0/Makefile.am
+++ b/common/gtk-2.0/Makefile.am
@@ -35,11 +35,7 @@ $(light): $(srcdir)/light/assets.svg | light/assets
 $(dark): $(srcdir)/dark/assets.svg | dark/assets
 
 $(light) $(dark):
-if INKSCAPE_1_0_OR_NEWER
-	$(INKSCAPE) --export-id-only --export-filename="$@" --export-id="$(basename $(notdir $@))" --export-dpi=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
-else !INKSCAPE_1_0_OR_NEWER
-	$(INKSCAPE) --export-id-only --export-png="$@" --export-id="$(basename $(notdir $@))" --export-dpi=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
-endif
+	$(RSVG_CONVERT) --format=png --output="$@" --export-id="$(basename $(notdir $@))" --dpi-x=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) --dpi-y=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
 	$(OPTIPNG) -o7 --quiet "$@"
 
 menubar-toolbar/%-dark.png: dark/assets/%.png | menubar-toolbar

--- a/common/gtk-3.0/common.am
+++ b/common/gtk-3.0/common.am
@@ -14,19 +14,11 @@ clean:
 	rm -rf assets/ light/ dark/ darker/ lighter/
 
 $(normal): $(srcdir)/assets.svg | assets
-if INKSCAPE_1_0_OR_NEWER
-	$(INKSCAPE) --export-id-only --export-filename="$@" --export-id="$(basename $(notdir $@))" --export-dpi=96 "$<" >/dev/null
-else !INKSCAPE_1_0_OR_NEWER
-	$(INKSCAPE) --export-id-only --export-png="$@" --export-id="$(basename $(notdir $@))" --export-dpi=96 "$<" >/dev/null
-endif
+	$(RSVG_CONVERT) --format=png --output="$@" --export-id="$(basename $(notdir $@))" --dpi-y=96 --dpi-x=96 "$<" >/dev/null
 	$(OPTIPNG) -o7 --quiet "$@"
 
 $(hidpi): $(srcdir)/assets.svg | assets
-if INKSCAPE_1_0_OR_NEWER
-	$(INKSCAPE) --export-id-only --export-filename="$@" --export-id="$(patsubst %@2,%,$(basename $(notdir $@)))" --export-dpi=192 "$<" >/dev/null
-else !INKSCAPE_1_0_OR_NEWER
-	$(INKSCAPE) --export-id-only --export-png="$@" --export-id="$(patsubst %@2,%,$(basename $(notdir $@)))" --export-dpi=192 "$<" >/dev/null
-endif
+	$(RSVG_CONVERT) --format=png --output="$@" --export-id="$(patsubst %@2,%,$(basename $(notdir $@)))" --dpi-y=192 --dpi-x=192 "$<" >/dev/null
 	$(OPTIPNG) -o7 --quiet "$@"
 
 .PHONY: normal hidpi clean

--- a/common/xfwm4/Makefile.am
+++ b/common/xfwm4/Makefile.am
@@ -17,11 +17,7 @@ $(light): $(srcdir)/light/assets.svg | light/assets
 $(dark): $(srcdir)/dark/assets.svg | dark/assets
 
 $(light) $(dark):
-if INKSCAPE_1_0_OR_NEWER
-	$(INKSCAPE) --export-id-only --export-filename="$@" --export-id="$(basename $(notdir $@))" --export-dpi=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
-else !INKSCAPE_1_0_OR_NEWER
-	$(INKSCAPE) --export-id-only --export-png="$@" --export-id="$(basename $(notdir $@))" --export-dpi=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
-endif
+	$(RSVG_CONVERT) --format=png --output="$@" --export-id="$(basename $(notdir $@))" --dpi-y=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) --dpi-x=$(if $(filter $(OPTION_GTK2_HIDPI),true),192,96) "$<" >/dev/null
 	$(OPTIPNG) -o7 --quiet "$@"
 
 .PHONY: light dark clean

--- a/configure.ac
+++ b/configure.ac
@@ -48,12 +48,8 @@ AM_CONDITIONAL([GNOME_SHELL_3_32_OR_NEWER], [test "0$GNOME_SHELL_VERSMNR" -ge 31
 AS_IF([test "x$ENABLE_CINNAMON" != xno], [ARC_CINNAMON])
 
 AS_IF([test "x$ENABLE_GTK2" != xno -o "x$ENABLE_GTK3" != xno -o "x$ENABLE_XFWM" != xno], [
-    AC_PATH_PROG([INKSCAPE], [inkscape])
-    AS_IF([test "x$ac_cv_path_INKSCAPE" = x], [AC_MSG_ERROR([inkscape not found])])
-    AS_IF([test "x$ac_cv_path_INKSCAPE" != x],
-        [INKSCAPE_VERSMJR=`inkscape --version 2> /dev/null | cut -d' ' -f2 | cut -d'.' -f1`]
-        AM_CONDITIONAL([INKSCAPE_1_0_OR_NEWER], [test "x$INKSCAPE_VERSMJR" = x1])
-    )
+    AC_PATH_PROG([RSVG_CONVERT], [rsvg-convert])
+    AS_IF([test "x$ac_cv_path_RSVG_CONVERT" = x], [AC_MSG_ERROR([rsvg-convert not found])])
     AC_PATH_PROG([OPTIPNG], [optipng])
     AS_IF([test "x$ac_cv_path_OPTIPNG" = x], [AC_MSG_ERROR([optipng not found])])
 ])


### PR DESCRIPTION
`rsvg-convert` is a *much* smaller dependency that all systems with a functioning GTK installation should have easy access to.

I admittedly have not done a thorough comparison of the output files but I wouldn't expect major compatibility problems.