### PR TITLE
gnome-shell: Fix login/unlock screens when Arc shell theme is compiled into a .gresource file (GNOME shell 3.36)

### DIFF
--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2573,7 +2573,7 @@ StScrollBar {
   font-weight: normal;
 }
 
-.screen-shield-notifications-container {
+.unlock-dialog-notifications-container {
   spacing: 6px;
   width: 30em;
   background-color: transparent;
@@ -2584,7 +2584,7 @@ StScrollBar {
   }
 
   .notification,
-  .screen-shield-notification-source {
+  .unlock-dialog-notification-source {
     padding: 12px 6px;
     border: 1px solid $_bubble_borders_color;
     background-color: transparentize($osd_bg_color,0.5);
@@ -2595,12 +2595,12 @@ StScrollBar {
 }
 
 
-.screen-shield-notification-label {
+.unlock-dialog-notification-label {
   font-weight: bold;
   padding: 0px 0px 0px 12px;
 }
 
-.screen-shield-notification-count-text { padding: 0px 0px 0px 12px; }
+.unlock-dialog-notification-count-text { padding: 0px 0px 0px 12px; }
 
 #panel.lock-screen { background-color: transparentize($_bubble_bg_color, 0.5); }
 
@@ -2614,7 +2614,7 @@ StScrollBar {
   background-repeat: repeat;
 }
 
-#screenShieldNotifications {
+#unlockDialogNotifications {
   StButton#vhandle, StButton#hhandle {
     background-color: transparentize($bg_color,0.7);
     &:hover, &:focus { background-color: transparentize($bg_color,0.5); }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2528,8 +2528,8 @@ StScrollBar {
   text-align: left;
   padding-left: 15px;
 
-  &:ltr { padding-left: 14px; }
-  &:rtl { padding-right: 14px; }
+  &:ltr { padding-left: 14px; text-align: left; }
+  &:rtl { padding-right: 14px; text-align: right; }
 }
 
 .user-widget.horizontal .user-icon {

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2458,7 +2458,8 @@ StScrollBar {
     }
   }
 
-  .cancel-button {
+  .cancel-button,
+  .login-dialog-session-list-button {
     padding: 0;
     border-radius: 99px;
     width: 32px;
@@ -2556,16 +2557,6 @@ StScrollBar {
   color: if($variant!='dark', lighten($fg_color, 10%), darken($fg_color, 20%));
   @include fontsize($font-size * 1.1);
   padding-top: 1em;
-}
-
-.login-dialog-session-list-button StIcon {
-  icon-size: 1.25em;
-}
-
-.login-dialog-session-list-button {
-  color: if($variant!='dark', lighten($fg_color, 20%), darken($fg_color, 30%));
-  &:hover,&:focus { color: $fg_color; }
-  &:active { color: if($variant!='dark', lighten($fg_color, 40%), darken($fg_color, 50%)); }
 }
 
 //

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2459,6 +2459,7 @@ StScrollBar {
   }
 
   .cancel-button,
+  .switch-user-button,
   .login-dialog-session-list-button {
     padding: 0;
     border-radius: 99px;

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2554,7 +2554,7 @@ StScrollBar {
 //
 // Screen Shield
 //
-.screen-shield-clock {
+.unlock-dialog-clock {
   color: white;
   text-shadow: 0px 1px 2px rgba(0,0,0,0.6);
   font-weight: bold;
@@ -2562,13 +2562,13 @@ StScrollBar {
   padding-bottom: 1.5em;
 }
 
-.screen-shield-clock-time {
+.unlock-dialog-clock-time {
   font-size: 72pt;
   text-shadow: 0px 2px 2px rgba(0,0,0,0.4);
   font-feature-settings: "tnum";
 }
 
-.screen-shield-clock-date {
+.unlock-dialog-clock-date {
   font-size: 28pt;
   font-weight: normal;
 }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2434,6 +2434,14 @@ StScrollBar {
   }
 }
 
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.horizontal .user-icon {
+  icon-size: 64px;
+}
+
 //
 // Login Dialog
 //
@@ -2532,19 +2540,11 @@ StScrollBar {
   &:rtl { padding-right: 14px; text-align: right; }
 }
 
-.user-widget.horizontal .user-icon {
-  icon-size: 64px;
-}
-
 .user-widget.vertical .user-widget-label {
   @include fontsize($font-size * 1.5);
   text-align: center;
   font-weight: normal;
   padding-top: 16px;
-}
-
-.user-widget.vertical .user-icon {
-  icon-size: 128px;
 }
 
 .login-dialog-prompt-layout {

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2500,19 +2500,33 @@ StScrollBar {
   &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
 }
 
-.login-dialog-username,
 .user-widget-label {
   color: $fg_color;
+}
+
+.user-widget.horizontal .user-widget-label {
   @include fontsize($font-size * 1.2);
   font-weight: bold;
   text-align: left;
   padding-left: 15px;
 
-  .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
-}
-.user-widget-label {
   &:ltr { padding-left: 14px; }
   &:rtl { padding-right: 14px; }
+}
+
+.user-widget.horizontal .user-icon {
+  icon-size: 64px;
+}
+
+.user-widget.vertical .user-widget-label {
+  @include fontsize($font-size * 1.5);
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
 }
 
 .login-dialog-prompt-layout {

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2432,14 +2432,31 @@ StScrollBar {
   &:hover {
     color: transparentize($fg_color, 0.3);
   }
+
+  & StIcon {
+    background-color: transparentize($osd_fg_color, 0.95);
+    border-radius: 99px;
+  }
 }
 
 .user-widget.vertical .user-icon {
   icon-size: 128px;
+
+  & StIcon {
+    padding: 20px;
+    padding-top: 18px;
+    padding-bottom: 22px;
+    width: 88px; height: 88px;
+  }
 }
 
 .user-widget.horizontal .user-icon {
   icon-size: 64px;
+
+  & StIcon {
+    padding: 12px;
+    width: 40px; height: 40px;
+  }
 }
 
 //

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2543,20 +2543,19 @@ StScrollBar {
 //
 .unlock-dialog-clock {
   color: white;
-  text-shadow: 0px 1px 2px rgba(0,0,0,0.6);
-  font-weight: bold;
+  font-weight: 300;
   text-align: center;
-  padding-bottom: 1.5em;
+  padding-bottom: 2.5em;
 }
 
 .unlock-dialog-clock-time {
-  font-size: 72pt;
-  text-shadow: 0px 2px 2px rgba(0,0,0,0.4);
+  font-size: 64pt;
+  padding-bottom: 24px;
   font-feature-settings: "tnum";
 }
 
 .unlock-dialog-clock-date {
-  font-size: 28pt;
+  font-size: 16pt;
   font-weight: normal;
 }
 

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2577,6 +2577,8 @@ StScrollBar {
     background-color: transparentize($osd_bg_color,0.5);
     color: $_bubble_fg_color;
     border-radius: 4px;
+
+    &.critical { background-color: transparentize($osd_bg_color,0.1) }
   }
   .notification { margin-right: 15px; } //compensate for space allocated to the scrollbar
 }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2457,6 +2457,17 @@ StScrollBar {
       &:insensitive { @include button(insensitive); }
     }
   }
+
+  .cancel-button {
+    padding: 0;
+    border-radius: 99px;
+    width: 32px;
+    height: 32px;
+    border-color: transparentize($bg_color,0.7);
+    background-color: transparentize($bg_color,0.7);
+
+    StIcon { icon-size: 16px; }
+  }
 }
 
 .login-dialog-logo-bin { padding: 24px 0px; }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -831,19 +831,6 @@ StScrollBar {
     }
   }
 
-  &.lock-screen {
-    border: none;
-
-    .panel-button {
-      color: $osd_fg_color;
-      &:hover { color: $osd_fg_color; }
-      &:focus, &:active, &:checked {
-        color: $selected_fg_color;
-        border-color: transparent;
-      }
-    }
-  }
-
   #panelLeft, #panelCenter { // spacing between activities<>app menu and such
     spacing: 8px;
   }
@@ -858,7 +845,7 @@ StScrollBar {
       -panel-corner-border-color: black;
     }
 
-    &.lock-screen, &.login-screen, &.unlock-screen {
+    &.login-screen, &.unlock-screen {
       -panel-corner-radius: 0;
       -panel-corner-background-color: transparent;
       -panel-corner-border-color: transparent;
@@ -2601,8 +2588,6 @@ StScrollBar {
 }
 
 .unlock-dialog-notification-count-text { padding: 0px 0px 0px 12px; }
-
-#panel.lock-screen { background-color: transparentize($_bubble_bg_color, 0.5); }
 
 .screen-shield-background { //just the shadow, really
   background: black;

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2566,10 +2566,10 @@ StScrollBar {
 }
 
 .unlock-dialog-notifications-container {
+  margin: 12px 0;
   spacing: 6px;
-  width: 30em;
+  width: 23em;
   background-color: transparent;
-  max-height: 500px;
   .summary-notification-stack-scrollview {
     padding-top: 0;
     padding-bottom: 0;
@@ -2585,16 +2585,16 @@ StScrollBar {
 
     &.critical { background-color: transparentize($osd_bg_color,0.1) }
   }
-  .notification { margin-right: 15px; } //compensate for space allocated to the scrollbar
 }
 
-
 .unlock-dialog-notification-label {
-  font-weight: bold;
   padding: 0px 0px 0px 12px;
 }
 
-.unlock-dialog-notification-count-text { padding: 0px 0px 0px 12px; }
+.unlock-dialog-notification-count-text {
+  font-weight: bold;
+  padding: 0px 12px;
+}
 
 .screen-shield-background { //just the shadow, really
   background: black;

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2571,12 +2571,12 @@ StScrollBar {
   color: white;
   font-weight: 300;
   text-align: center;
+  spacing: 24px;
   padding-bottom: 2.5em;
 }
 
 .unlock-dialog-clock-time {
   font-size: 64pt;
-  padding-bottom: 24px;
   padding-top: 42px;
   font-feature-settings: "tnum";
 }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2469,13 +2469,17 @@ StScrollBar {
 
     StIcon { icon-size: 16px; }
   }
+
+  .caps-lock-warning-label,
+  .login-dialog-message-warning {
+    color: $osd_fg_color;
+  }
 }
 
 .login-dialog-logo-bin { padding: 24px 0px; }
 .login-dialog-banner { color: if($variant!='dark', lighten($fg_color, 10%), darken($fg_color, 20%)); }
 .login-dialog-button-box { width: 23em; spacing: 5px; }
 .login-dialog-message { text-align: center; }
-.login-dialog-message-warning { color: $warning_color; }
 .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
 .login-dialog-user-selection-box { padding: 100px 0px; }
 .login-dialog-not-listed-label {

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2597,8 +2597,7 @@ StScrollBar {
 }
 
 #lockDialogGroup {
-  background: if($variant!='dark', darken($bg_color, 10%), darken($bg_color, 5%));
-  background-repeat: repeat;
+  background-color: if($variant!='dark', darken($bg_color, 10%), darken($bg_color, 5%));
 }
 
 #unlockDialogNotifications {

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2560,6 +2560,11 @@ StScrollBar {
   font-weight: normal;
 }
 
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
 .unlock-dialog-notifications-container {
   spacing: 6px;
   width: 30em;

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2461,7 +2461,7 @@ StScrollBar {
 
 .login-dialog-logo-bin { padding: 24px 0px; }
 .login-dialog-banner { color: if($variant!='dark', lighten($fg_color, 10%), darken($fg_color, 20%)); }
-.login-dialog-button-box { spacing: 5px; }
+.login-dialog-button-box { width: 23em; spacing: 5px; }
 .login-dialog-message-warning { color: $warning_color; }
 .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
 .login-dialog-user-selection-box { padding: 100px 0px; }
@@ -2534,6 +2534,11 @@ StScrollBar {
   padding-bottom: 12px;
   spacing: 8px;
   width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  width: 17.89em;
+  height: 1.5em;
 }
 
 .login-dialog-prompt-label {

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2551,6 +2551,7 @@ StScrollBar {
 .unlock-dialog-clock-time {
   font-size: 64pt;
   padding-bottom: 24px;
+  padding-top: 42px;
   font-feature-settings: "tnum";
 }
 

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2555,7 +2555,6 @@ StScrollBar {
 }
 
 .login-dialog-prompt-entry {
-  width: 17.89em;
   height: 1.5em;
 }
 

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2474,6 +2474,7 @@ StScrollBar {
 .login-dialog-logo-bin { padding: 24px 0px; }
 .login-dialog-banner { color: if($variant!='dark', lighten($fg_color, 10%), darken($fg_color, 20%)); }
 .login-dialog-button-box { width: 23em; spacing: 5px; }
+.login-dialog-message { text-align: center; }
 .login-dialog-message-warning { color: $warning_color; }
 .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
 .login-dialog-user-selection-box { padding: 100px 0px; }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2554,18 +2554,6 @@ StScrollBar {
 //
 // Screen Shield
 //
-.screen-shield-arrows {
-  padding-bottom: 3em;
-}
-
-.screen-shield-arrows Gjs_Arrow {
-  color: white;
-  width: 80px;
-  height: 48px;
-  -arrow-thickness: 12px;
-  -arrow-shadow: 0 1px 1px rgba(0,0,0,0.4);
-}
-
 .screen-shield-clock {
   color: white;
   text-shadow: 0px 1px 2px rgba(0,0,0,0.6);


### PR DESCRIPTION
Back after a long absence ... and back with my GDM fixation

The login and unlock screen have been completely re-designed in GNOME shell 3.36 - with significant changes in the CSS code.
This PR aims to re-factor the CSS code to reflect upstream changes.

At this point, **no significant Arc styling has been done**; commits to date simply reflect upstream changes in the following elements: login dialog, screen shield, user avatar, panel. I aim to continue with styling of the various elements of the login and unlock screens - unless there are any concerns or significant comments at this stage.