### PR TITLE
gnome-shell: Add Arc styling for GNOME 3.36 GDM login/unlock screens

### DIFF
--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2526,7 +2526,7 @@ StScrollBar {
 }
 
 .login-dialog-logo-bin { padding: 24px 0px; }
-.login-dialog-banner { color: $osd_fg_color; }
+.login-dialog-banner { color: $osd_fg_color; @include fontsize($font-size * 1.1); }
 .login-dialog-button-box { width: 23em; spacing: 5px; }
 .login-dialog-message { text-align: center; }
 .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2526,7 +2526,7 @@ StScrollBar {
 }
 
 .login-dialog-logo-bin { padding: 24px 0px; }
-.login-dialog-banner { color: if($variant!='dark', lighten($fg_color, 10%), darken($fg_color, 20%)); }
+.login-dialog-banner { color: $osd_fg_color; }
 .login-dialog-button-box { width: 23em; spacing: 5px; }
 .login-dialog-message { text-align: center; }
 .login-dialog-message-hint { padding-top: 0; padding-bottom: 20px; }
@@ -2535,13 +2535,13 @@ StScrollBar {
   padding-left: 2px;
   .login-dialog-not-listed-button:focus &,
   .login-dialog-not-listed-button:hover & {
-    color: $fg_color;
+    color: if($variant != 'lighter', lighten($osd_fg_color, 25%), darken($osd_fg_color, 12%));
   }
 }
 .login-dialog-not-listed-label {
   @include fontsize($font-size * 0.9);
   font-weight: bold;
-  color: if($variant!='dark', lighten($fg_color, 20%), darken($fg_color, 30%));
+  color: $osd_fg_color;
   padding-top: 1em;
 }
 
@@ -2555,13 +2555,13 @@ StScrollBar {
 .login-dialog-user-list-item {
   border-radius: 5px;
   padding: 6px;
-  color: if($variant!='dark', lighten($fg_color, 20%), darken($fg_color, 30%));
+  color: $osd_fg_color;
   &:ltr .user-widget { padding-right: 1em; }
   &:rtl .user-widget { padding-left: 1em; }
   .login-dialog-timed-login-indicator {
     height: 2px;
     margin-top: 6px;
-    background-color: $fg_color;
+    background-color: $osd_fg_color;
   }
   &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
 }
@@ -2598,7 +2598,7 @@ StScrollBar {
 }
 
 .login-dialog-prompt-label {
-  color: if($variant!='dark', lighten($fg_color, 10%), darken($fg_color, 20%));
+  color: $osd_fg_color;
   @include fontsize($font-size * 1.1);
   padding-top: 1em;
 }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2614,7 +2614,7 @@ StScrollBar {
 // Screen Shield
 //
 .unlock-dialog-clock {
-  color: white;
+  color: $_shell_fg_color;
   font-weight: 300;
   text-align: center;
   spacing: 24px;

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2563,7 +2563,7 @@ StScrollBar {
     margin-top: 6px;
     background-color: $osd_fg_color;
   }
-  &:focus .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
+  &:selected .login-dialog-timed-login-indicator { background-color: $selected_fg_color; }
 }
 
 .user-widget-label {

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2650,12 +2650,11 @@ StScrollBar {
   .notification,
   .unlock-dialog-notification-source {
     padding: 12px 6px;
-    border: 1px solid $_bubble_borders_color;
-    background-color: transparentize($osd_bg_color,0.5);
-    color: $_bubble_fg_color;
-    border-radius: 4px;
+    @extend %popup_menu;
 
-    &.critical { background-color: transparentize($osd_bg_color,0.1) }
+    StIcon { -st-icon-style: symbolic; }
+
+    // &.critical { background-color: transparentize($osd_bg_color,0.1) } // FIXME
   }
 }
 
@@ -2666,8 +2665,9 @@ StScrollBar {
 .unlock-dialog-notification-count-text {
   font-weight: bold;
   padding: 0 6px;
-  color: $osd_bg_color;
-  background-color: transparentize($osd_fg_color, 0.7);
+  color: $fg_color;
+  border: 1px solid if($variant != 'lighter', transparentize(white, 0.9), transparentize(black, 0.9));
+  background-color: if($variant != 'lighter', transparentize(white, 0.8), transparentize(black, 0.8));
   border-radius: 99px;
   margin-right: 12px;
 }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2484,11 +2484,8 @@ StScrollBar {
   .modal-dialog-button-box { spacing: 3px; }
   .modal-dialog-button {
     padding: 3px 18px;
-    &:default {
-      @include button(normal);
-      &:hover,&:focus { @include button(hover); }
-      &:active { @include button(active); }
-      &:insensitive { @include button(insensitive); }
+    &, &:default {
+      @extend %osd_button;
     }
   }
 
@@ -2499,8 +2496,6 @@ StScrollBar {
     border-radius: 99px;
     width: 32px;
     height: 32px;
-    border-color: transparentize($bg_color,0.7);
-    background-color: transparentize($bg_color,0.7);
 
     StIcon { icon-size: 16px; }
   }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2436,15 +2436,20 @@ StScrollBar {
 //
 .user-icon {
   background-size: contain;
-  color: $fg_color;
+  color: $osd_fg_color;
   border-radius: 99px;
+
+  .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
+
   &:hover {
-    color: transparentize($fg_color, 0.3);
+    color: $osd_fg_color;
   }
 
   & StIcon {
-    background-color: transparentize($osd_fg_color, 0.95);
+    background-color: transparentize($osd_fg_color, 0.75);
     border-radius: 99px;
+
+    .login-dialog-user-list-item:selected & { background-color: transparentize($selected_fg_color, 0.75); }
   }
 }
 

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2567,7 +2567,9 @@ StScrollBar {
 }
 
 .user-widget-label {
-  color: $fg_color;
+  color: $osd_fg_color;
+
+  .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
 }
 
 .user-widget.horizontal .user-widget-label {

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -822,11 +822,20 @@ StScrollBar {
     border: none;
 
     .panel-button {
-      color: $fg_color;
-      &:hover { color: $fg_color; }
       &:focus, &:active, &:checked {
-        color: $selected_fg_color;
-        border-color: transparent;
+        &, &.clock-display .clock {
+          color: $selected_fg_color;
+          border-color: transparent;
+        }
+      }
+    }
+  }
+  &.unlock-screen {
+    .panel-button {
+      color: $_shell_fg_color;
+
+      &:hover {
+        color: $_shell_fg_color;
       }
     }
   }

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2481,6 +2481,25 @@ StScrollBar {
   border: none;
   background-color: transparent;
 
+  StEntry {
+    caret-color: $selected_fg_color;
+    selection-background-color: $selected_bg_color;
+    selected-color: $selected_fg_color;
+
+    @include entry(osd);
+
+    StLabel.hint-text { color: transparentize($osd_fg_color, 0.3); }
+
+    &:focus {
+      selection-background-color: $selected_fg_color;
+      selected-color: $selected_bg_color;
+
+      @include entry(osd-focus);
+
+      StLabel.hint-text { color: transparentize($selected_fg_color, 0.3); }
+    }
+  }
+
   .modal-dialog-button-box { spacing: 3px; }
   .modal-dialog-button {
     padding: 3px 18px;

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2644,7 +2644,7 @@ StScrollBar {
 }
 
 #lockDialogGroup {
-  background-color: if($variant!='dark', darken($bg_color, 10%), darken($bg_color, 5%));
+  background-color: opacify($osd_bg_color, 1);
 }
 
 #unlockDialogNotifications {

--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -2665,7 +2665,11 @@ StScrollBar {
 
 .unlock-dialog-notification-count-text {
   font-weight: bold;
-  padding: 0px 12px;
+  padding: 0 6px;
+  color: $osd_bg_color;
+  background-color: transparentize($osd_fg_color, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
 }
 
 .screen-shield-background { //just the shadow, really


### PR DESCRIPTION
Following up on https://github.com/jnsh/arc-theme/pull/68, opening separate PR for Arc styling of GDM login/unlock screens.

Quoting here open points of conversation from https://github.com/jnsh/arc-theme/pull/68:

> I had a very brief look at the code, and one thing is I'd like to avoid is adding extra color variables to `_colors.scss`, and would prefer always using the existing palette if possible. This will help keeping the theme consistent with the original design (originally the `_colors.scss` was identical between all the SASS themes). I admit that the color definitions could be much cleaner, but any improvements on that matter should be done more comprehensively, and in separate commits.
> 
> If it makes the code cleaner, you can add local `$_gdm_*_color variables`, either right above all the login/lock screen stylings, or at the top of the `_common.scss`. Still try to re-use the old color swatches, or add some darken(), lighten() etc. preferably based on other elements, if necessary.

For the moment I have opted for local `$_gdm_*` color variables, as it makes the code easier to maintain - but let me know what you think

> My actual issue is with the use of fully rounded entry style, since seems to be a special case for the search-bar only, while rest of the entries are the standard square ones. Therefore it would make more sense to me to use the latter style for the login/unlock entries as well, especially since that's what upstream is doing also.
>
> You're right that the login entry has to by styled separately, in order to get it right for the login screen background colors, but maybe just use the regular square style?

Password entry now square like the OSD password entries, with colors adjusted to differentiate between Arc-Lighter and other variants.

>>> Did you include the icons in the .gresource? They aren't present in the Arc codebase but you can copy them from the default theme: eye-not-looking-symbolic.svg, eye-open-negative-filled-symbolic.svg.

>> I did try to include the icons, but may have messed up the relative paths - will take another look.

> I got this to work at some point, and I think you had to use the alias= attribute similarly as how it's done in the default gnome-shell-theme.gresource.xml, but unfortunately I couldn't find the .gresource.xml any more and can't remember the exact details.

Thanks for the tip on the `alias` attribute in the XML file. I have tested this and it works in the login and unlock screens. I will add the icons with a later commit. Think I will also have to add other icons that are not included in the Arc theme, to make sure the overall theme works.

> After the login/unlock styling is complete, it would be nice to finally add the pre-made *.gresource.xml files for people who want to compile it themselves.

Good point

~~**Styling not yet complete, will be adding additional commits**~~