### PR TITLE
Add build instructions using containers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:focal AS build-arc-theme-deps
+
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# non-obvious dependencies:
+#   glib-compile-resources from libglib2.0-dev-bin
+#   gdk-pixbuf-pixdata from libgdk-pixbuf2.0-bin
+RUN apt update \
+ && apt install -y --no-install-recommends \
+    autoconf \
+    automake \
+    inkscape \
+    libglib2.0-dev-bin \
+    libgdk-pixbuf2.0-bin \
+    make \
+    optipng \
+    pkgconf \
+    sassc \
+ && rm -rf /var/lib/apt/lists/*
+
+
+
+FROM build-arc-theme-deps
+
+# allow handing in build options
+# see https://github.com/jnsh/arc-theme/blob/master/INSTALL.md#build-options
+ARG BUILD_OPTIONS
+
+# copy source directory into the container
+COPY . /build/src
+WORKDIR /build/src
+
+# configure, build and install inside the container
+RUN ./autogen.sh --prefix=/build/artifacts $BUILD_OPTIONS
+RUN make -j$(nproc) install
+
+# copy final theme directories out of the container
+VOLUME /install
+RUN test -d /install && cp -r /build/artifacts/share/themes/* /install/


### PR DESCRIPTION
In case someone wants to build/install this theme from source without "cluttering" their machine with all the build dependencies I've added the necessary information to build the theme using containers (i.e. Docker/Podman). :slightly_smiling_face: 

Notable things:
* Auto-detection of desktop and library versions won't work.
* There're some [non-obvious/indirect build dependencies](https://github.com/jnsh/arc-theme/compare/master...riyad:build-with-container?expand=1#diff-74154d062e5eecd6626420347ec88c90R6) that aren't mentioned in the documentation.
* This is currently "optimized" for building/installing the theme. If you want to use containers also for development it would probably need some tweaking to make it more ergonomic for that use case.