### PR TITLE
gnome-shell: Fix window "jump" issue when entering/leaving overview (3.38)

### DIFF
--- a/common/gnome-shell/3.38/sass/_common.scss
+++ b/common/gnome-shell/3.38/sass/_common.scss
@@ -1642,7 +1642,7 @@ StScrollBar {
 
 .window-picker { //container around window thumbnails
   spacing: 6px;
-  padding: 0 12px 12px;
+  padding: 12px;
 
   &.external-monitor { padding: 12px; }
 }


### PR DESCRIPTION
Fixes https://github.com/jnsh/arc-theme/issues/87. The issue with windows "jumping" when entering/leaving the overview is caused by the `padding` property in the `.window-picker` code block:

```css
.window-picker { //container around window thumbnails
  spacing: 6px;
  padding: 0 12px 12px;

  &.external-monitor { padding: 12px; }
}
```

The whole block of code appears to be obsolete, and should be removed, IMO (not present in upstream code).