### PR TITLE
gnome-shell: Fix search results in overview (3.38)

### DIFF
--- a/common/gnome-shell/3.38/sass/_common.scss
+++ b/common/gnome-shell/3.38/sass/_common.scss
@@ -1711,8 +1711,6 @@ StScrollBar {
 //
 #searchResultsContent {
   max-width: 1000px;
-  padding-left: 20px;
-  padding-right: 20px;
   spacing: 16px;
 }
 


### PR DESCRIPTION
Search results appear incomplete in the GNOME shell overview (empty space/missing sixth result on right):

![search338](https://user-images.githubusercontent.com/18715287/95489622-67232400-0997-11eb-9f88-e15a4971c9d7.png)

In some cases, this also causes flickering in the search results: https://drive.google.com/file/d/1keT0e19PRmrnTg-O-0w8GAFxeYTdT1Hj/view?usp=sharing.

This is fixed by removing redundant `padding` properties in the `#searchResultsContent` code block (properties not present in upstream code).


