### PR TITLE
gnome-shell: Add border around user icon (3.38.1)

### DIFF
--- a/common/gnome-shell/3.38/sass/_common.scss
+++ b/common/gnome-shell/3.38/sass/_common.scss
@@ -2426,11 +2426,16 @@ StScrollBar {
   background-size: contain;
   color: $osd_fg_color;
   border-radius: 99px;
+  border: 2px solid $osd_fg_color;
 
-  .login-dialog-user-list-item:selected & { color: $selected_fg_color; }
+  .login-dialog-user-list-item:selected & {
+    color: $selected_fg_color;
+    border-color: $selected_fg_color;
+  }
 
   &:hover {
     color: $osd_fg_color;
+    border-color: $osd_fg_color;
   }
 
   & StIcon {


### PR DESCRIPTION
Border around user icons (avatars) added in upstream code in GNOME shell point release 3.38.1.

~~An additional change in the upstream code that removes specific styling for the polkit dialog user icon is not yet included in the 3.38.1 point release, but it could makes sense to add to the Arc theme as of now (https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/9d5165b1aa5ad11662c9c02cbf161fd7004e3f05)~~ (this would break styling right now)