### PR TITLE
gnome-shell: Fix some over large font sizes

### DIFF
--- a/common/gnome-shell/3.36/sass/_common.scss
+++ b/common/gnome-shell/3.36/sass/_common.scss
@@ -298,11 +298,11 @@ StScrollBar {
 
   .message-dialog-title {
     text-align: center;
-    @include fontsize($font-size * 2);
+    @include fontsize($font-size * 1.6);
     font-weight: 800;
 
     &.leightweight {
-      @include fontsize($font-size * 1.44);
+      @include fontsize($font-size * 1.2);
       font-weight: 800;
     }
   }
@@ -2043,7 +2043,7 @@ StScrollBar {
 
     & .folder-name-label,
     & .folder-name-entry {
-      @include fontsize($font-size * 2);
+      @include fontsize($font-size * 1.6);
       font-weight: bold;
     }
 
@@ -2217,7 +2217,7 @@ StScrollBar {
 
 .chat-meta-message {
   padding-left: 4px;
-  @include fontsize($font-size);
+  @include fontsize($font-size * 0.8);
   font-weight: bold;
   color: transparentize($fg_color, 0.4);
 
@@ -2285,7 +2285,7 @@ StScrollBar {
 // On-Screen Keyboard
 //
 .word-suggestions {
-  @include fontsize($font-size * 1.6);
+  @include fontsize($font-size * 1.25);
   spacing: 12px;
   min-height: 20pt;
 
@@ -2322,7 +2322,7 @@ StScrollBar {
 .keyboard-key {
   min-height: 1.2em;
   min-width: 1.2em;
-  @include fontsize($font-size * 1.8);
+  @include fontsize($font-size * 1.44);
   border-radius: 3px;
   box-shadow: none;
 

--- a/common/gnome-shell/3.38/sass/_common.scss
+++ b/common/gnome-shell/3.38/sass/_common.scss
@@ -298,11 +298,11 @@ StScrollBar {
 
   .message-dialog-title {
     text-align: center;
-    @include fontsize($font-size * 2);
+    @include fontsize($font-size * 1.6);
     font-weight: 800;
 
     &.lightweight {
-      @include fontsize($font-size * 1.44);
+      @include fontsize($font-size * 1.2);
       font-weight: 800;
     }
   }
@@ -2033,7 +2033,7 @@ StScrollBar {
 
     & .folder-name-label,
     & .folder-name-entry {
-      @include fontsize($font-size * 2);
+      @include fontsize($font-size * 1.6);
       font-weight: 800;
     }
 
@@ -2217,7 +2217,7 @@ StScrollBar {
 
 .chat-meta-message {
   padding-left: 4px;
-  @include fontsize($font-size);
+  @include fontsize($font-size * 0.8);
   font-weight: bold;
   color: transparentize($fg_color, 0.4);
 
@@ -2285,7 +2285,7 @@ StScrollBar {
 // On-Screen Keyboard
 //
 .word-suggestions {
-  @include fontsize($font-size * 1.6);
+  @include fontsize($font-size * 1.25);
   spacing: 12px;
   min-height: 20pt;
 
@@ -2322,7 +2322,7 @@ StScrollBar {
 .keyboard-key {
   min-height: 1.2em;
   min-width: 1.2em;
-  @include fontsize($font-size * 1.8);
+  @include fontsize($font-size * 1.44);
   border-radius: 3px;
   box-shadow: none;
 


### PR DESCRIPTION
Likely as a result of the shell font size being changed from 9pt to 11pt (https://github.com/jnsh/arc-theme/commit/e672981af6dff3e7896310aa8118ff01624a9538) just after the commit to streamline font sizes with the font mixin (https://github.com/jnsh/arc-theme/commit/7c7aaa5be18d314b7e9a8cc2cb16d8dc3810791e), some font sizes in GNOME shell are visually too large - and significantly larger than upstream.

Affects the following classes:

```scss
.message-dialog-title
.message-dialog-title.lightweight
.folder-name-label / .folder-name-entry
.chat-meta-message
.word-suggestions
.keyboard-key
```

This PR reduces font sizes for selected classes to align with upstream (and fix visual appearance)