### PR TITLE
gtk3: Fix nautilus path bar

### DIFF
--- a/common/gtk-3.0/3.24/sass/_applications.scss
+++ b/common/gtk-3.0/3.24/sass/_applications.scss
@@ -105,13 +105,13 @@ terminal-window,
 
     border-width: 0;
 
-    &:only-child {
-      border-radius: 3px 0px 0px 3px;
-    }
-
     &:last-child {
       border-radius: 0;
       border-right-width: 1px;
+    }
+
+    &:only-child {
+      border-radius: 3px 0px 0px 3px;
     }
   }
 

--- a/common/gtk-3.0/3.24/sass/_applications.scss
+++ b/common/gtk-3.0/3.24/sass/_applications.scss
@@ -71,6 +71,7 @@ terminal-window,
 .nautilus-window .path-bar-box {
   border-radius: 3px;
   border: 1px $header_button_border solid;
+  background: lighten($header_bg, 5%);
 }
 
 // path-bar buttons for nautilus 3.30


### PR DESCRIPTION
Proposed fix for the border-only styling of the path bar - introduced with the re-positioning of the search button in the nautilus header. See https://github.com/jnsh/arc-theme/issues/96

![pathbar-light](https://user-images.githubusercontent.com/18715287/97787816-b0d8e600-1bb4-11eb-8bfd-2fc8a3bc7b77.png)

![pathbar-dark](https://user-images.githubusercontent.com/18715287/97787819-b5050380-1bb4-11eb-9833-4e350a922301.png)


I have used `lighten($header_bg, 5%)` for the `.path-bar` background, which yields visual results very similar to those of the baobab path bar. The baobab path bar uses the `$bg_color` color variable, but this will not work for the Arc-Darker variant. This is actually a bug in the baobab path bar styling - which has a light path bar on dark background when using the Arc-Darker variant.

I had also attempted to use the `$header_button_bg` color variable (which seemed the obvious choice), but (IMO) this makes for too great a contrast between the path bar and the header.

Also includes a fix for the border radius of the path bar button, when the button is an only child. Currently, when the button is an only child, top-left/bottom-left border radius is 0, while it should be 3px.
