### PR TITLE
gtk3: Thunar fix 4.16 spinner background

### DIFF
--- a/common/gtk-3.0/3.24/sass/_applications.scss
+++ b/common/gtk-3.0/3.24/sass/_applications.scss
@@ -248,6 +248,10 @@ sushi-media-bin box.overlay-bar { @extend %osd; }
     @extend %header_widgets;
   }
 
+  grid > box {
+    background-color: opacify($header_bg, 1);
+  }
+
   scrolledwindow.sidebar treeview.view {
     background: $dark_sidebar_bg;
     color: $dark_sidebar_fg;


### PR DESCRIPTION
In Thunar 4.16 a spinner was added to the menu bar. Using arc-theme-gtk-git this results in the wrong background.
This commit seem to resolve the issue without causing trouble. I'm not really happy with the selectors, but I could not think of anything else to use.

## Before
**arc**
![image](https://user-images.githubusercontent.com/5833571/103154301-e2c28f00-4796-11eb-8e36-f0708cc20a2f.png)
**arc-dark**
![image](https://user-images.githubusercontent.com/5833571/103154306-e6eeac80-4796-11eb-9dde-3f1a1f71ecf4.png)
**arc-darker**
![image](https://user-images.githubusercontent.com/5833571/103154286-c6beed80-4796-11eb-81f9-d72276436c31.png)
**arc-lighter**
![image](https://user-images.githubusercontent.com/5833571/103154312-f1a94180-4796-11eb-9eed-09c857abb84f.png)

## After
**arc**
![image](https://user-images.githubusercontent.com/5833571/103154395-56649c00-4797-11eb-9147-99172cc34d9f.png)
**arc-dark**
![image](https://user-images.githubusercontent.com/5833571/103154402-5e244080-4797-11eb-8ca4-5c05d4b8ee50.png)
**arc-darker**
![image](https://user-images.githubusercontent.com/5833571/103154406-654b4e80-4797-11eb-923c-ac6aad5e7acb.png)
**arc-lighter**
![image](https://user-images.githubusercontent.com/5833571/103154409-6bd9c600-4797-11eb-8e71-54a442361d1c.png)


