### PR TITLE
For GTK2, building just the dark variant fails if the expected light variant assets are not also built.

### DIFF
--- a/common/gtk-2.0/meson.build
+++ b/common/gtk-2.0/meson.build
@@ -3,10 +3,7 @@ gtk2_asset_names = run_command(
   check : true
 ).stdout().split()
 
-if 'light' in get_option('variants') or 'lighter' in get_option('variants')
-  subdir('light')
-endif
-
+subdir('light')
 if 'dark' in get_option('variants') or 'darker' in get_option('variants')
   subdir('dark')
 endif


### PR DESCRIPTION
For GTK2, building just the dark variant fails if the expected light variant assets are not also built. Reason: the dark and darker variants use both 'light_menubar_toolbar_assets' and 'dark_menubar_toolbar_assets'. Fix: always build the light assets.