### PR TITLE
Try to fix build with samurai

### DIFF
--- a/common/gtk-3.0/meson.build
+++ b/common/gtk-3.0/meson.build
@@ -42,8 +42,11 @@ gtk3_asset_names = run_command(
 
 assets_svg = gtk3_ver / 'assets.svg'
 
+gtk3_assets = []
+gtk3_hidpi_assets = []
+
 foreach asset : gtk3_asset_names
-  gtk3_assets = custom_target(
+  gtk3_assets += custom_target(
     'gtk3-' + asset,
     input : assets_svg,
     output : asset + '.png',
@@ -58,7 +61,7 @@ foreach asset : gtk3_asset_names
     build_by_default : true
   )
 
-  gtk3_hidpi_assets = custom_target(
+  gtk3_hidpi_assets += custom_target(
     'gtk3-' + asset + '-hidpi',
     input : assets_svg,
     output : asset + '@2.png',


### PR DESCRIPTION
There appears to be build order bug and the build fails with

samu: job failed: /usr/local/bin/glib-compile-resources --sourcedir=common/gtk-3.0 --target=common/gtk-3.0/gtk-lighter.gresource common/gtk-3.0/gtk-lighter.gresource.xml
common/gtk-3.0/gtk-lighter.gresource.xml: Failed to locate checkbox-checked.png

It seems that dependencies on some assets are not properly specified.

Samurai is a Ninja-compatible build tool [0].  The above failure
can probably also happen with Ninja given a sufficient number of
build jobs.

[0] https://github.com/michaelforney/samurai