### PR TITLE
Use SVG instead of PNG assets for GTK3

### DIFF
--- a/common/gtk-3.0/3.18/sass/_common.scss
+++ b/common/gtk-3.0/3.18/sass/_common.scss
@@ -1924,22 +1924,22 @@ GtkSwitch {
                (':insensitive','-insensitive'),
                (':active:insensitive','-active-insensitive') {
 
-  // load switch troughs from .png files in assets directory
+  // load switch troughs from .svg files in assets directory
 
   GtkSwitch.trough#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}#{$asset_suffix}.png"),url("assets/switch#{$l}#{$asset_suffix}@2.png"));
+    background-image: url("assets/switch#{$l}#{$asset_suffix}.svg");
   }
 
   WingpanelWidgetsIndicatorPopover.popover .menuitem:hover GtkSwitch.trough#{$k},
   .menu .menuitem:hover GtkSwitch.trough#{$k},
   .list-row:selected GtkSwitch.trough#{$k},
   GtkInfoBar GtkSwitch.trough#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}-selected.png"),url("assets/switch#{$l}-selected@2.png"));
+    background-image: url("assets/switch#{$l}-selected.svg");
   }
 
   .header-bar GtkSwitch.trough#{$k},
   .primary-toolbar GtkSwitch.trough#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}-header#{$darker_asset_suffix}.png"),url("assets/switch#{$l}-header#{$darker_asset_suffix}@2.png"));
+    background-image: url("assets/switch#{$l}-header#{$darker_asset_suffix}.svg");
   }
 }
 
@@ -1957,14 +1957,12 @@ GtkSwitch {
                   (':checked', '-checked'),
                   (':checked:insensitive','-checked-insensitive') {
     .#{$w}#{$s} {
-      -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}#{$asset_suffix}.png"),
-                                    url("assets/#{$a}#{$as}#{$asset_suffix}@2.png"));
+      -gtk-icon-source: url("assets/#{$a}#{$as}#{$asset_suffix}.svg");
     }
 
     %osd_check_radio {
       .#{$w}#{$s} {
-        -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}-dark.png"),
-                                      url("assets/#{$a}#{$as}-dark@2.png"));
+        -gtk-icon-source: url("assets/#{$a}#{$as}-dark.svg");
       }
     }
     // the borders of checks and radios are
@@ -1975,8 +1973,7 @@ GtkSwitch {
     GtkTreeView.view.#{$w}#{$s}:selected,
     .list-row:selected .#{$w}#{$s},
     GtkInfoBar .#{$w}#{$s} {
-      -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}-selected.png"),
-                                    url("assets/#{$a}#{$as}-selected@2.png"));
+      -gtk-icon-source: url("assets/#{$a}#{$as}-selected.svg");
     }
   }
 }
@@ -1985,8 +1982,7 @@ GtkSwitch {
 @each $s,$as in ('','-selectionmode'),
                   (':checked', '-checked-selectionmode') {
   .view.content-view.check#{$s}:not(.list) {
-    -gtk-icon-source: -gtk-scaled(url("assets/checkbox#{$as}#{$asset_suffix}.png"),
-                                    url("assets/checkbox#{$as}#{$asset_suffix}@2.png"));
+    -gtk-icon-source: url("assets/checkbox#{$as}#{$asset_suffix}.svg");
     background-color: transparent;
   }
 }
@@ -2860,12 +2856,11 @@ GtkVolumeButton.button { padding: 8px; }
 
       &:backdrop { opacity: 1; }
     }
-    // Load png assets for each button
+    // Load svg assets for each button
     @each $k in ('close','maximize', 'minimize') {
       @each $l, $m in ('',''), (':backdrop','-backdrop'), (':hover','-hover'), (':active','-active') {
 
-        &.#{$k}#{$l} { background-image: -gtk-scaled(url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}.png'),
-                                                     url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}@2.png')); }
+        &.#{$k}#{$l} { background-image: url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}.svg'); }
       }
     }
   }

--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -2053,21 +2053,21 @@ switch {
                (':disabled','-insensitive'),
                (':checked:disabled','-active-insensitive') {
 
-  // load switch troughs from .png files in assets directory
+  // load switch troughs from .svg files in assets directory
 
   switch#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}#{$asset_suffix}.png"),url("assets/switch#{$l}#{$asset_suffix}@2.png"));
+    background-image: url("assets/switch#{$l}#{$asset_suffix}.svg");
   }
 
   menuitem:hover switch#{$k},
   row:selected switch#{$k},
   infobar switch#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}-selected.png"),url("assets/switch#{$l}-selected@2.png"));
+    background-image: url("assets/switch#{$l}-selected.svg");
   }
 
   headerbar switch#{$k},
   .primary-toolbar switch#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}-header#{$darker_asset_suffix}.png"),url("assets/switch#{$l}-header#{$darker_asset_suffix}@2.png"));
+    background-image: url("assets/switch#{$l}-header#{$darker_asset_suffix}.svg");
   }
 }
 
@@ -2087,15 +2087,13 @@ switch {
     .#{$w}#{$s},
     #{$w}#{$s},
     treeview.#{$w}#{$s} {
-      -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}#{$asset_suffix}.png"),
-                                    url("assets/#{$a}#{$as}#{$asset_suffix}@2.png"));
+      -gtk-icon-source: url("assets/#{$a}#{$as}#{$asset_suffix}.svg");
     }
 
     .osd,
     %osd_check_radio {
       #{$w}#{$s} {
-        -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}-dark.png"),
-                                      url("assets/#{$a}#{$as}-dark@2.png"));
+        -gtk-icon-source: url("assets/#{$a}#{$as}-dark.svg");
       }
     }
     // the borders of checks and radios are
@@ -2106,8 +2104,7 @@ switch {
     treeview.#{$w}#{$s}:selected,
     row:selected #{$w}#{$s},
     infobar #{$w}#{$s} {
-      -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}-selected.png"),
-                                    url("assets/#{$a}#{$as}-selected@2.png"));
+      -gtk-icon-source: url("assets/#{$a}#{$as}-selected.svg");
     }
   }
 }
@@ -2116,8 +2113,7 @@ switch {
 @each $s,$as in ('','-selectionmode'),
                   (':checked', '-checked-selectionmode') {
   .view.content-view.check#{$s}:not(list) {
-    -gtk-icon-source: -gtk-scaled(url("assets/checkbox#{$as}#{$asset_suffix}.png"),
-                                    url("assets/checkbox#{$as}#{$asset_suffix}@2.png"));
+    -gtk-icon-source: url("assets/checkbox#{$as}#{$asset_suffix}.svg");
     background-color: transparent;
   }
 }
@@ -3239,12 +3235,11 @@ headerbar,
 
       &:backdrop { opacity: 1; }
     }
-    // Load png assets for each button
+    // Load svg assets for each button
     @each $k in ('close','maximize', 'minimize') {
       @each $l, $m in ('',''), (':backdrop','-backdrop'), (':hover','-hover'), (':active','-active') {
 
-        &.#{$k}#{$l} { background-image: -gtk-scaled(url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}.png'),
-                                                     url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}@2.png')); }
+        &.#{$k}#{$l} { background-image: url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}.svg'); }
       }
     }
   }

--- a/common/gtk-3.0/3.22/sass/_common.scss
+++ b/common/gtk-3.0/3.22/sass/_common.scss
@@ -2091,21 +2091,21 @@ switch {
                (':disabled','-insensitive'),
                (':checked:disabled','-active-insensitive') {
 
-  // load switch troughs from .png files in assets directory
+  // load switch troughs from .svg files in assets directory
 
   switch#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}#{$asset_suffix}.png"),url("assets/switch#{$l}#{$asset_suffix}@2.png"));
+    background-image: url("assets/switch#{$l}#{$asset_suffix}.svg");
   }
 
   menuitem:hover switch#{$k},
   row:selected switch#{$k},
   infobar switch#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}-selected.png"),url("assets/switch#{$l}-selected@2.png"));
+    background-image: url("assets/switch#{$l}-selected.svg");
   }
 
   headerbar switch#{$k},
   .primary-toolbar switch#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}-header#{$darker_asset_suffix}.png"),url("assets/switch#{$l}-header#{$darker_asset_suffix}@2.png"));
+    background-image: url("assets/switch#{$l}-header#{$darker_asset_suffix}.svg");
   }
 }
 
@@ -2125,15 +2125,13 @@ switch {
     .#{$w}#{$s},
     #{$w}#{$s},
     treeview.#{$w}#{$s} {
-      -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}#{$asset_suffix}.png"),
-                                    url("assets/#{$a}#{$as}#{$asset_suffix}@2.png"));
+      -gtk-icon-source: url("assets/#{$a}#{$as}#{$asset_suffix}.svg");
     }
 
     .osd,
     %osd_check_radio {
       #{$w}#{$s} {
-        -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}-dark.png"),
-                                      url("assets/#{$a}#{$as}-dark@2.png"));
+        -gtk-icon-source: url("assets/#{$a}#{$as}-dark.svg");
       }
     }
     // the borders of checks and radios are
@@ -2144,8 +2142,7 @@ switch {
     treeview.#{$w}#{$s}:selected,
     row:selected #{$w}#{$s},
     infobar #{$w}#{$s} {
-      -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}-selected.png"),
-                                    url("assets/#{$a}#{$as}-selected@2.png"));
+      -gtk-icon-source: url("assets/#{$a}#{$as}-selected.svg");
     }
   }
 }
@@ -2154,8 +2151,7 @@ switch {
 @each $s,$as in ('','-selectionmode'),
                   (':checked', '-checked-selectionmode') {
   .view.content-view.check#{$s}:not(list) {
-    -gtk-icon-source: -gtk-scaled(url("assets/checkbox#{$as}#{$asset_suffix}.png"),
-                                    url("assets/checkbox#{$as}#{$asset_suffix}@2.png"));
+    -gtk-icon-source: url("assets/checkbox#{$as}#{$asset_suffix}.svg");
     background-color: transparent;
   }
 }
@@ -3296,12 +3292,11 @@ headerbar,
 
       &:backdrop { opacity: 1; }
     }
-    // Load png assets for each button
+    // Load svg assets for each button
     @each $k in ('close','maximize', 'minimize') {
       @each $l, $m in ('',''), (':backdrop','-backdrop'), (':hover','-hover'), (':active','-active') {
 
-        &.#{$k}#{$l} { background-image: -gtk-scaled(url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}.png'),
-                                                     url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}@2.png')); }
+        &.#{$k}#{$l} { background-image: url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}.svg'); }
       }
     }
   }

--- a/common/gtk-3.0/3.24/sass/_common.scss
+++ b/common/gtk-3.0/3.24/sass/_common.scss
@@ -2110,21 +2110,21 @@ switch {
                (':disabled','-insensitive'),
                (':checked:disabled','-active-insensitive') {
 
-  // load switch troughs from .png files in assets directory
+  // load switch troughs from .svg files in assets directory
 
   switch#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}#{$asset_suffix}.png"),url("assets/switch#{$l}#{$asset_suffix}@2.png"));
+    background-image: url("assets/switch#{$l}#{$asset_suffix}.svg");
   }
 
   menuitem:hover switch#{$k},
   row:selected switch#{$k},
   infobar switch#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}-selected.png"),url("assets/switch#{$l}-selected@2.png"));
+    background-image: url("assets/switch#{$l}-selected.svg");
   }
 
   headerbar switch#{$k},
   .primary-toolbar switch#{$k} {
-    background-image: -gtk-scaled(url("assets/switch#{$l}-header#{$darker_asset_suffix}.png"),url("assets/switch#{$l}-header#{$darker_asset_suffix}@2.png"));
+    background-image: url("assets/switch#{$l}-header#{$darker_asset_suffix}.svg");
   }
 }
 
@@ -2144,15 +2144,13 @@ switch {
     .#{$w}#{$s},
     #{$w}#{$s},
     treeview.#{$w}#{$s} {
-      -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}#{$asset_suffix}.png"),
-                                    url("assets/#{$a}#{$as}#{$asset_suffix}@2.png"));
+      -gtk-icon-source: url("assets/#{$a}#{$as}#{$asset_suffix}.svg");
     }
 
     .osd,
     %osd_check_radio {
       #{$w}#{$s} {
-        -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}-dark.png"),
-                                      url("assets/#{$a}#{$as}-dark@2.png"));
+        -gtk-icon-source: url("assets/#{$a}#{$as}-dark.svg");
       }
     }
     // the borders of checks and radios are
@@ -2163,8 +2161,7 @@ switch {
     treeview.#{$w}#{$s}:selected,
     row:selected #{$w}#{$s},
     infobar #{$w}#{$s} {
-      -gtk-icon-source: -gtk-scaled(url("assets/#{$a}#{$as}-selected.png"),
-                                    url("assets/#{$a}#{$as}-selected@2.png"));
+      -gtk-icon-source: url("assets/#{$a}#{$as}-selected.svg");
     }
   }
 }
@@ -2173,8 +2170,7 @@ switch {
 @each $s,$as in ('','-selectionmode'),
                   (':checked', '-checked-selectionmode') {
   .view.content-view.check#{$s}:not(list) {
-    -gtk-icon-source: -gtk-scaled(url("assets/checkbox#{$as}#{$asset_suffix}.png"),
-                                    url("assets/checkbox#{$as}#{$asset_suffix}@2.png"));
+    -gtk-icon-source: url("assets/checkbox#{$as}#{$asset_suffix}.svg");
     background-color: transparent;
   }
 }
@@ -3319,12 +3315,11 @@ headerbar,
 
       &:backdrop { opacity: 1; }
     }
-    // Load png assets for each button
+    // Load svg assets for each button
     @each $k in ('close','maximize', 'minimize') {
       @each $l, $m in ('',''), (':backdrop','-backdrop'), (':hover','-hover'), (':active','-active') {
 
-        &.#{$k}#{$l} { background-image: -gtk-scaled(url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}.png'),
-                                                     url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}@2.png')); }
+        &.#{$k}#{$l} { background-image: url('assets/titlebutton-#{$k}#{$m}#{$darker_asset_suffix}.svg'); }
       }
     }
   }

--- a/common/gtk-3.0/meson.build
+++ b/common/gtk-3.0/meson.build
@@ -33,7 +33,7 @@ if gtk3_ver not in gtk3_versions
   endif
 endif
 
-# render PNG assets
+# render SVG assets
 
 gtk3_asset_names = run_command(
   'cat', gtk3_ver / 'assets.txt',
@@ -43,34 +43,18 @@ gtk3_asset_names = run_command(
 assets_svg = gtk3_ver / 'assets.svg'
 
 gtk3_assets = []
-gtk3_hidpi_assets = []
 
 foreach asset : gtk3_asset_names
   gtk3_assets += custom_target(
     'gtk3-' + asset,
     input : assets_svg,
-    output : asset + '.png',
+    output : asset + '.svg',
     command : [
       inkscape,
       '--export-id-only',
-      inkscape_ver.version_compare('>=1.0') ? '--export-filename=@OUTPUT@' : '--export-png=@OUTPUT@',
+      inkscape_ver.version_compare('>=1.0') ? '--export-filename=@OUTPUT@' : '--export-svg=@OUTPUT@',
       '--export-id=' + asset,
       '--export-dpi=96',
-      '@INPUT@'
-    ],
-    build_by_default : true
-  )
-
-  gtk3_hidpi_assets += custom_target(
-    'gtk3-' + asset + '-hidpi',
-    input : assets_svg,
-    output : asset + '@2.png',
-    command : [
-      inkscape,
-      '--export-id-only',
-      inkscape_ver.version_compare('>=1.0') ? '--export-filename=@OUTPUT@' : '--export-png=@OUTPUT@',
-      '--export-id=' + asset,
-      '--export-dpi=192',
       '@INPUT@'
     ],
     build_by_default : true
@@ -130,8 +114,7 @@ foreach variant : get_option('variants')
   #TODO update asset paths in SASS files and get rid of the alias=
   foreach asset : gtk3_asset_names
     gresource_xml_array += [
-      '<file preprocess="to-pixdata" alias="assets/' + asset + '.png">' + asset + '.png</file>',
-      '<file preprocess="to-pixdata" alias="assets/' + asset + '@2.png">' + asset + '@2.png</file>'
+      '<file preprocess="to-pixdata" alias="assets/' + asset + '.svg">' + asset + '.svg</file>',
     ]
   endforeach
 
@@ -165,7 +148,7 @@ foreach variant : get_option('variants')
       '--target=@OUTPUT@',
       '@INPUT@'
     ],
-    depends : [gtk3_assets, gtk3_hidpi_assets, gtk3_stylesheet],
+    depends : [gtk3_assets, gtk3_stylesheet],
     build_by_default : true
   )
 


### PR DESCRIPTION
This achieves several results:
* Reduces size of gresource archives from 1.4M to 649K.
* Assets render better at non-integer scale factors and
  scale factors greater than 2.
* Net negative lines-of-code.